### PR TITLE
In 01_intro.ipynb: Corrected "edit" mode to "command" for kernel restart.

### DIFF
--- a/01_intro.ipynb
+++ b/01_intro.ipynb
@@ -2172,7 +2172,7 @@
     "\n",
     "Except when we mention it explicitely, the notebooks provided on the book website are meant to be run in order, from top to bottom. In general, when experimenting, you will find yourself executing cells in any order to go fast (which is a super neat feature of Jupyter Notebooks) but once you have explored and arrive at the final version of your code, make sure you can run the cells of your notebooks in order (your future self won't necessarily remember the convoluted path you took otherwise!). \n",
     "\n",
-    "In edit mode, pressing `0` twice will restart the *kernel* (which is the engine powering your notebook). This will wipe your state clean and make it as if you had just started in the notebook. Clean then on the \"Cell\" menu and then on \"Run All Above\" to run all the cells above the point you are. We have found this to be very useful when developing the fastai library."
+    "In command mode, pressing `0` twice will restart the *kernel* (which is the engine powering your notebook). This will wipe your state clean and make it as if you had just started in the notebook. Clean then on the \"Cell\" menu and then on \"Run All Above\" to run all the cells above the point you are. We have found this to be very useful when developing the fastai library."
    ]
   },
   {
@@ -2876,7 +2876,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.5"
+   "version": "3.7.6"
   },
   "toc": {
    "base_numbering": 1,


### PR DESCRIPTION
Corrected the mode for restarting kernel.
In "command" mode, pressing `0` twice will restart the *kernel* instead of In "edit mode".