### PR TITLE
fix the OR operator

### DIFF
--- a/09_tabular.ipynb
+++ b/09_tabular.ipynb
@@ -700,7 +700,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "cond = (df.saleYear<2011) | (df.saleMonth<10)\n",
+    "cond = (df.saleYear<2011) & (df.saleMonth<10)\n",
     "train_idx = np.where( cond)[0]\n",
     "valid_idx = np.where(~cond)[0]\n",
     "\n",
@@ -9751,7 +9751,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.5"
+   "version": "3.7.2"
   },
   "toc": {
    "base_numbering": 1,


### PR DESCRIPTION
This is to define the training index as described in the book:
"So we will define a narrower training dataset which consists only of the Kaggle training data from before November 2011 ..."

I think the correct operator might be & instead of | below:
cond = (df.saleYear<2011) | (df.saleMonth<10)