### PR TITLE
Correct spelling 15_arch_details - transfert to transfer

### DIFF
--- a/15_arch_details.ipynb
+++ b/15_arch_details.ipynb
@@ -389,7 +389,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "More importantly, to take full advantage of transfer learning, we have to define a custom *splitter*. A splitter is a function that tells the fastai library how to split the model in several parameter groups. This is what is used behind the scenes not only train the head of a model when we do transfert learning. \n",
+    "More importantly, to take full advantage of transfer learning, we have to define a custom *splitter*. A splitter is a function that tells the fastai library how to split the model in several parameter groups. This is what is used behind the scenes not only train the head of a model when we do transfer learning. \n",
     "\n",
     "Here we want two parameter groups: one for the encoder and one for the head. We can thus define the following splitter (`params` is jsut a function that returns all parameters of a given module):"
    ]


### PR DESCRIPTION
Replace "transfert learning" with "transfer learning"