### PR TITLE
Remove unnecessary word "them" in 01_intro.ipynb, line 160

### DIFF
--- a/01_intro.ipynb
+++ b/01_intro.ipynb
@@ -157,7 +157,7 @@
     "\n",
     "Although researchers showed 30 years ago that to get practical good performance you need to use even more layers of neurons, it is only in the last decade that this has been more widely appreciated. Neural networks are now finally living up to their potential, thanks to the understanding to use more layers as well as improved ability to do so thanks to improvements in computer hardware, increases in data availability, and algorithmic tweaks that allow neural networks to be trained faster and more easily. We now have what Rosenblatt had promised: \"a machine capable of perceiving, recognizing and identifying its surroundings without any human training or control\".\n",
     "\n",
-    "This is what you will learn how to build them in this book."
+    "This is what you will learn how to build in this book."
    ]
   },
   {


### PR DESCRIPTION
"Them" should be removed from "This is what you will learn how to build **them** in this book."