### PR TITLE
Capitalize "s" for Sylvain's sidebar, 01_intro.ipynb, line 398

### DIFF
--- a/01_intro.ipynb
+++ b/01_intro.ipynb
@@ -395,7 +395,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "> s: Do not skip the setup part even if it looks intimidating at first, especially if you have little or no experience using things like a terminal or the command line. Most of that is actually not necessary and you will find that the easiest servers can be setup with just your usual web browser. It is crucial that you run your own experiments in parallel with this book in order to learn."
+    "> S: Do not skip the setup part even if it looks intimidating at first, especially if you have little or no experience using things like a terminal or the command line. Most of that is actually not necessary and you will find that the easiest servers can be setup with just your usual web browser. It is crucial that you run your own experiments in parallel with this book in order to learn."
    ]
   },
   {


### PR DESCRIPTION
The "J: " and "S: " before all the other sidebars from Jeremy and Sylvain are capitalized, so this one should be too, instead of "s: "
Or maybe that lowercase s stands for "sidebar", in which case this change is invalid.