### PR TITLE
FIX Biwi dataset link

### DIFF
--- a/06_multicat.ipynb
+++ b/06_multicat.ipynb
@@ -1245,7 +1245,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We will use the [Biwi Kinect Head Pose Dataset](https://data.vision.ee.ethz.ch/cvl/gfanelli/head_pose/head_forest.html#db) for this section. First thing first, let's begin by downloading the dataset as usual."
+    "We will use the [Biwi Kinect Head Pose Dataset](https://icu.ee.ethz.ch/research/datsets.html) for this section. First thing first, let's begin by downloading the dataset as usual."
    ]
   },
   {


### PR DESCRIPTION
Looks like the BIWI dataset is not at the same page anymore.

I think that the reason is that the first author had the dataset page in his personal section of the ETH site, and he's not there anymore (apparently he works at Apple now). 

This is the best approximation I could find, although there is no download link anymore.