### PR TITLE
Update 12_nlp_dive.ipynb Small change

### DIFF
--- a/12_nlp_dive.ipynb
+++ b/12_nlp_dive.ipynb
@@ -685,7 +685,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "> Jargon: hidden state: the activations that are updated at each step of a recurrent neural network"
+    "> jargon: hidden state: the activations that are updated at each step of a recurrent neural network"
    ]
   },
   {


### PR DESCRIPTION
Change: 

Jargon -->> jargon

Reasoning: Since in the rest of the book the word 'jargon' is not capitalized, thought it could be a mistake. 