### PR TITLE
Minor Typo in 10_nlp.ipynb

### DIFF
--- a/10_nlp.ipynb
+++ b/10_nlp.ipynb
@@ -739,7 +739,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "When dealing with images, we needed to resize them all to the same height and width before grouping them together in a mini-batch so they could stack together efficiently in a single tensor. Here it's going to be a little different, because one cannot simply resize text to a desired length. Also, we want our language model to read text in order, so that it can efficiently predict what the next word is. this means that each new batch should begin precisely where the previous one left off.\n",
+    "When dealing with images, we needed to resize them all to the same height and width before grouping them together in a mini-batch so they could stack together efficiently in a single tensor. Here it's going to be a little different, because one cannot simply resize text to a desired length. Also, we want our language model to read text in order, so that it can efficiently predict what the next word is. This means that each new batch should begin precisely where the previous one left off.\n",
     "\n",
     "Suppose we have the following text:\n",
     "\n",


### PR DESCRIPTION
Change `. this` to `. This`. I'm not sure if typo fixes are still relevant since the book is published but I found it while reading so I just thought I'd make the PR.

Feel free to close if no longer relevant