### PR TITLE
Minor typo fix in app_jupyter.ipynb

### DIFF
--- a/app_jupyter.ipynb
+++ b/app_jupyter.ipynb
@@ -491,7 +491,7 @@
     "\n",
     "- `%matplotlib inline`:: Ensures that all matplotlib plots will be plotted in the output cell within the notebook and will be kept in the notebook when saved.\n",
     "\n",
-    "This command is always called together at the beggining of every notebook of the fast.ai course.\n",
+    "This command is always called together at the beginning of every notebook of the fast.ai course.\n",
     "\n",
     "``` python\n",
     "%matplotlib inline\n",


### PR DESCRIPTION
Corrected the spelling of beginning in the given line: This command is always called together at the `beggining` of every notebook of the fast.ai course