### PR TITLE
grammar correction to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,14 +4,14 @@
 
 These draft notebooks cover an introduction to deep learning, [fastai](https://docs.fast.ai/), and [PyTorch](https://pytorch.org/). fastai is a layered API for deep learning; for more information, see [the fastai paper](https://www.mdpi.com/2078-2489/11/2/108). Everything in this repo is copyright Jeremy Howard and Sylvain Gugger, 2020 onwards.
 
-These notebooks will be used for [a course we're teaching](https://www.usfca.edu/data-institute/certificates/deep-learning-part-one) in San Francisco from March 2020, and will be available as a MOOC from around July 2020. In addition, our plan is that these notebooks will form the basis of [this book](https://www.amazon.com/Deep-Learning-Coders-fastai-PyTorch/dp/1492045527), which you can pre-order. It will not have the same GPL restrictions that are on this draft.
+These notebooks will be used for [a course we're teaching](https://www.usfca.edu/data-institute/certificates/deep-learning-part-one) in San Francisco from March 2020 and will be available as a MOOC from around July 2020. In addition, our plan is that these notebooks will form the basis of [this book](https://www.amazon.com/Deep-Learning-Coders-fastai-PyTorch/dp/1492045527), which you can pre-order. It will not have the same GPL restrictions that are on this draft.
 
 The code in the notebooks and python `.py` files is covered by the GPL v3 license; see the LICENSE file for details.
 
 The remainder (including all markdown cells in the notebooks and other prose) is not licensed for any redistribution or change of format or medium, other than making copies of the notebooks or forking this repo for your own private use. No commercial or broadcast use is allowed. We are making these materials freely available to help you learn deep learning, so please respect our copyright and these restrictions.
 
-If you see someone hosting a copy of these materials somewhere else, please let them know that their actions are not allowed, and may lead to legal action. Moreover, they would be hurting the community, because we're not likely to release additional materials in this way if people ignore our copyright.
+If you see someone hosting a copy of these materials somewhere else, please let them know that their actions are not allowed and may lead to legal action. Moreover, they would be hurting the community because we're not likely to release additional materials in this way if people ignore our copyright.
 
 This is an early draft. If you get stuck running notebooks, please search the [fastai-v2 forum](https://forums.fast.ai/c/fastai-users/fastai-v2) for answers, and ask for help there if needed. Please don't use GitHub issues for problems running the notebooks.
 
-If you make any pull requests to this repo, then you are assigning copyright of that work to Jeremy Howard and Sylvain Gugger. (Additionally, if you are making small edits to spelling or text, please specify the name of the file and very brief description of what you're fixing. It's becoming increasingly difficult for reviewers to know which corrections have already been made. Thank you.)
+If you make any pull requests to this repo, then you are assigning copyright of that work to Jeremy Howard and Sylvain Gugger. (Additionally, if you are making small edits to spelling or text, please specify the name of the file and a very brief description of what you're fixing. It's becoming increasingly difficult for reviewers to know which corrections have already been made. Thank you.)


### PR DESCRIPTION
removed unnecessary commas from:
'San Francisco from March 2020,'
'know that their actions are not allowed,'
'they would be hurting the community,'

Also fixed:
'please specify the name of the file and very brief description...' to 'please specify the name of the file and a very brief description'