### PR TITLE
Fix voila install instructios

### DIFF
--- a/02_production.ipynb
+++ b/02_production.ipynb
@@ -1685,7 +1685,7 @@
    "source": [
     "#hide\n",
     "# !pip install voila\n",
-    "# !jupyter serverextension enable voila —sys-prefix"
+    "# !jupyter serverextension enable --sys-prefix voila "
    ]
   },
   {
@@ -1697,7 +1697,7 @@
     "Next, install Voilà if you haven't already, by copying these lines into a notebook cell and executing it:\n",
     "\n",
     "    !pip install voila\n",
-    "    !jupyter serverextension enable voila —sys-prefix\n",
+    "    !jupyter serverextension enable --sys-prefix voila\n",
     "\n",
     "Cells that begin with a `!` do not contain Python code, but instead contain code that is passed to your shell (bash, Windows PowerShell, etc.). If you are comfortable using the command line, which we'll discuss more later in this book, you can of course simply type these two lines (without the `!` prefix) directly into your terminal. In this case, the first line installs the `voila` library and application, and the second connects it to your existing Jupyter notebook.\n",
     "\n",


### PR DESCRIPTION
Thank you for fastai, it's so helpful/interesting


When going through the notebook 02_production I tried to install voila. It looks like the instructions no longer work, so I've updated them.

I'm using the paperspace console for fastai