### PR TITLE
typo-fix-for-cp9

### DIFF
--- a/09_tabular.ipynb
+++ b/09_tabular.ipynb
@@ -9283,7 +9283,6 @@
     "xs_filt2 = xs_filt.drop('fiModelDescriptor', axis=1)\n",
     "valid_xs_time2 = valid_xs_time.drop('fiModelDescriptor', axis=1)\n",
     "m2 = rf(xs_filt2, y_filt)\n",
-    "m_rmse(m, xs_filt2, y_filt), m_rmse(m2, valid_xs_time2, valid_y)"
     "m_rmse(m2, xs_filt2, y_filt), m_rmse(m2, valid_xs_time2, valid_y)"
    ]
   },

--- a/09_tabular.ipynb
+++ b/09_tabular.ipynb
@@ -9284,6 +9284,7 @@
     "valid_xs_time2 = valid_xs_time.drop('fiModelDescriptor', axis=1)\n",
     "m2 = rf(xs_filt2, y_filt)\n",
     "m_rmse(m, xs_filt2, y_filt), m_rmse(m2, valid_xs_time2, valid_y)"
+    "m_rmse(m2, xs_filt2, y_filt), m_rmse(m2, valid_xs_time2, valid_y)"
    ]
   },
   {


### PR DESCRIPTION
Based on context, `m2` should be used instead of `m`.