### PR TITLE
Change indent to download images even if target directory exists

### DIFF
--- a/02_production.ipynb
+++ b/02_production.ipynb
@@ -447,11 +447,11 @@
    "source": [
     "if not path.exists():\n",
     "    path.mkdir()\n",
-    "    for o in bear_types:\n",
-    "        dest = (path/o)\n",
-    "        dest.mkdir(exist_ok=True)\n",
-    "        results = search_images_bing(key, f'{o} bear')\n",
-    "        download_images(dest, urls=results.attrgot('content_url'))"
+    "for o in bear_types:\n",
+    "    dest = (path/o)\n",
+    "    dest.mkdir(exist_ok=True)\n",
+    "    results = search_images_bing(key, f'{o} bear')\n",
+    "    download_images(dest, urls=results.attrgot('content_url'))"
    ]
   },
   {


### PR DESCRIPTION
In chapter 2, the current behavior is to download images only if the target directory doesn't exist. I think it would make sense to proceed with the downloading even if the directory has been already created.