### PR TITLE
Fix link to Markkula's Ethical Lenses

### DIFF
--- a/03_ethics.ipynb
+++ b/03_ethics.ipynb
@@ -766,7 +766,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Another useful resource from the Markkula Center is its [Conceptual Frameworks in Technology and Engineering Practice](https://www.scu.edu/ethics-in-technology-practice/conceptual-frameworks/). This considers how different foundational ethical lenses can help identify concrete issues, and lays out the following approaches and key questions:\n",
+    "Another useful resource from the Markkula Center is its [Conceptual Frameworks in Technology and Engineering Practice](https://www.scu.edu/ethics-in-technology-practice/ethical-lenses/). This considers how different foundational ethical lenses can help identify concrete issues, and lays out the following approaches and key questions:\n",
     "\n",
     "  - The rights approach:: Which option best respects the rights of all who have a stake?\n",
     "  - The justice approach:: Which option treats people equally or proportionately?\n",


### PR DESCRIPTION
The current link (https://www.scu.edu/ethics-in-technology-practice/conceptual-frameworks) returns a 404.
Based on an online search, the new link seems to be https://www.scu.edu/ethics-in-technology-practice/ethical-lenses/.

Please correct me if I'm wrong.