### PR TITLE
typo in NN section of 09_tabular.ipynb, referencing to wrong model 'm'

### DIFF
--- a/09_tabular.ipynb
+++ b/09_tabular.ipynb
@@ -9283,7 +9283,7 @@
     "xs_filt2 = xs_filt.drop('fiModelDescriptor', axis=1)\n",
     "valid_xs_time2 = valid_xs_time.drop('fiModelDescriptor', axis=1)\n",
     "m2 = rf(xs_filt2, y_filt)\n",
-    "m_rmse(m, xs_filt2, y_filt), m_rmse(m2, valid_xs_time2, valid_y)"
+    "m_rmse(m2, xs_filt2, y_filt), m_rmse(m2, valid_xs_time2, valid_y)"
    ]
   },
   {
@@ -9839,7 +9839,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.7"
+   "version": "3.8.5"
   },
   "toc": {
    "base_numbering": 1,


### PR DESCRIPTION
The model `m` gives an error while running, which says input sizes are not matching. 

I'm not sure if its okay to change the Python version, since that's what was running on my system. This is my first ever contribution, so please let me know if something's wrong.