### PR TITLE
Update 13_convolutions.ipynb

### DIFF
--- a/13_convolutions.ipynb
+++ b/13_convolutions.ipynb
@@ -2416,7 +2416,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The *receptive field* is the area of an image that is involved in the calculation of a layer. On the [book's website](https://book.fast.ai/), you'll find an Excel spreadsheet called *conv-example.xlsx* that shows the calculation of two stride-2 convolutional layers using an MNIST digit. Each layer has a single kernel. <<preced1>> shows what we see if we click on one of the cells in the *conv2* section, which shows the output of the second convolutional layer, and click *trace precedents*."
+    "The *receptive field* is the area of an image that is involved in the calculation of a layer. Each layer has a single kernel. <<preced1>> shows what we see if we click on one of the cells in the *conv2* section, which shows the output of the second convolutional layer, and click *trace precedents*."
    ]
   },
   {


### PR DESCRIPTION
Remove comment on "conv-example.xlsx" file not available in the website. Or add the link (https://github.com/fastai/courses/blob/master/deeplearning1/excel/entropy_example.xlsx)