### PR TITLE
Chapter 4 misspelling - 'backard pass' -> 'backward pass'

### DIFF
--- a/04_mnist_basics.ipynb
+++ b/04_mnist_basics.ipynb
@@ -5761,7 +5761,7 @@
     "|Forward pass | Applying the model to some input and computing the predictions.\n",
     "|Loss | A value that represents how well (or badly) our model is doing.\n",
     "|Gradient | The derivative of the loss with respect to some parameter of the model.\n",
-    "|Backard pass | Computing the gradients of the loss with respect to all model parameters.\n",
+    "|Backward pass | Computing the gradients of the loss with respect to all model parameters.\n",
     "|Gradient descent | Taking a step in the directions opposite to the gradients to make the model parameters a little bit better.\n",
     "|Learning rate | The size of the step we take when applying SGD to update the parameters of the model.\n",
     "|=====\n",


### PR DESCRIPTION
file: **04_mnist_basics.ipynb** 
fix: Small misspelling -  "**Backward** pass"  is misspelt as "**Backard** pass"