### PR TITLE
04_mnist_basics typo

### DIFF
--- a/04_mnist_basics.ipynb
+++ b/04_mnist_basics.ipynb
@@ -2109,7 +2109,7 @@
     "\n",
     "We ultimately want to write a function, `is_3`, that will decide if an arbitrary image is a 3 or a 7. It will do this by deciding which of our two \"ideal digits\" this arbitrary image is closer to. For that we need to define a notion of distance—that is, a function that calculates the distance between two images.\n",
     "\n",
-    "We can write a simple function that calculates the mean absolute error using an experssion very similar to the one we wrote in the last section:"
+    "We can write a simple function that calculates the mean absolute error using an expression very similar to the one we wrote in the last section:"
    ]
   },
   {
@@ -5867,7 +5867,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.7"
+   "version": "3.8.5"
   },
   "toc": {
    "base_numbering": 1,


### PR DESCRIPTION
Found typo "experssion" instead of "expression" in markup above mnist_distance function cell 