### PR TITLE
replaced `write` with `mk_write` in Chapter 9

### DIFF
--- a/09_tabular.ipynb
+++ b/09_tabular.ipynb
@@ -317,7 +317,7 @@
     "cred_path = Path('~/.kaggle/kaggle.json').expanduser()\n",
     "if not cred_path.exists():\n",
     "    cred_path.parent.mkdir(exist_ok=True)\n",
-    "    cred_path.write(creds)\n",
+    "    cred_path.mk_write(creds)\n",
     "    cred_path.chmod(0o600)"
    ]
   },
@@ -9839,7 +9839,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.5"
+   "version": "3.7.3"
   },
   "toc": {
    "base_numbering": 1,


### PR DESCRIPTION
It seems that `write` is replaced with `mk_write` in the latest version of fastcore 16 days ago, as shown in the source code.

https://github.com/fastai/fastcore/commit/b1d27bfc1c527f745f52b8e1ede8a37fd7a11771#diff-7a62211d84f0badeff2ebd35250b596631098901684ce0b01a2b0c4acc41f552
 