### PR TITLE
04_mnist_basics: MSE lacks .sqrt()

### DIFF
--- a/04_mnist_basics.ipynb
+++ b/04_mnist_basics.ipynb
@@ -3013,7 +3013,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "def mse(preds, targets): return ((preds-targets)**2).mean()"
+    "def mse(preds, targets): return ((preds-targets)**2).mean().sqrt()"
    ]
   },
   {


### PR DESCRIPTION
A definition of MSE loss function lacks square operation, which may be misleading.