### PR TITLE
02_production: Updates needed for new Bing Image Search API

### DIFF
--- a/02_production.ipynb
+++ b/02_production.ipynb
@@ -451,7 +451,7 @@
     "        dest = (path/o)\n",
     "        dest.mkdir(exist_ok=True)\n",
     "        results = search_images_bing(key, f'{o} bear')\n",
-    "        download_images(dest, urls=results.attrgot('content_url'))"
+    "        download_images(dest, urls=results.attrgot('contentUrl'))"
    ]
   },
   {

--- a/utils.py
+++ b/utils.py
@@ -28,9 +28,14 @@ def get_image_files_sorted(path, recurse=True, folders=None): return get_image_f
 from azure.cognitiveservices.search.imagesearch import ImageSearchClient as api
 from msrest.authentication import CognitiveServicesCredentials as auth
 
-def search_images_bing(key, term, min_sz=128):
-    client = api('https://api.cognitive.microsoft.com', auth(key))
-    return L(client.images.search(query=term, count=150, min_height=min_sz, min_width=min_sz).value)
+def search_images_bing(key, term, min_sz=128, max_images=150):    
+     params = {'q':term, 'count':max_images, 'min_height':min_sz, 'min_width':min_sz}
+     headers = {"Ocp-Apim-Subscription-Key":key}
+     search_url = "https://api.bing.microsoft.com/v7.0/images/search"
+     response = requests.get(search_url, headers=headers, params=params)
+     response.raise_for_status()
+     search_results = response.json()    
+     return L(search_results['value'])
 
 
 # -


### PR DESCRIPTION
Hi FastAI team,

There have been some recent updates to the Bing Image Search API, and 02_production.ipynb no longer works out of the box as a result. There has been some discussion about this over on the forums over the past few months:

https://forums.fast.ai/t/02-production-permissiondenied-error/65823/19

I don't see any pull requests created yet, so I went ahead and proposed the following changes: 

1. Update search_images_bing() function in utils.py
2. Update the call to download_images in 02_production.ipynb
