### PR TITLE
fix typo in notebook 17

### DIFF
--- a/17_foundations.ipynb
+++ b/17_foundations.ipynb
@@ -1093,7 +1093,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Another useful wat of simplifying tensor manipulations is the use of Einstein summations convention."
+    "Another useful way of simplifying tensor manipulations is the use of Einstein summations convention."
    ]
   },
   {


### PR DESCRIPTION
its just "wat" -> "way". Amazing book though.