### PR TITLE
09_tabular: wrong splitting of training/validation set (fix issue #325)

### DIFF
--- a/09_tabular.ipynb
+++ b/09_tabular.ipynb
@@ -732,7 +732,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "cond = (df.saleYear<2011) | (df.saleMonth<10)\n",
+    "cond = (df.saleYear<2011) | (df.saleYear==2011) & (df.saleMonth<10)\n",
     "train_idx = np.where( cond)[0]\n",
     "valid_idx = np.where(~cond)[0]\n",
     "\n",


### PR DESCRIPTION
fix #325 (https://github.com/fastai/fastbook/issues/325)