### PR TITLE
fixed incorrect method call - torch.stack should be torch.cat, and fixed incorrect variable name

### DIFF
--- a/12_nlp_dive.ipynb
+++ b/12_nlp_dive.ipynb
@@ -1614,14 +1614,14 @@
     "\n",
     "    def forward(self, input, state):\n",
     "        h,c = state\n",
-    "        h = torch.stack([h, input], dim=1)\n",
+    "        h = torch.cat([h, input], dim=1)\n",
     "        forget = torch.sigmoid(self.forget_gate(h))\n",
     "        c = c * forget\n",
     "        inp = torch.sigmoid(self.input_gate(h))\n",
     "        cell = torch.tanh(self.cell_gate(h))\n",
     "        c = c + inp * cell\n",
     "        out = torch.sigmoid(self.output_gate(h))\n",
-    "        h = outgate * torch.tanh(c)\n",
+    "        h = out * torch.tanh(c)\n",
     "        return h, (h,c)"
    ]
   },


### PR DESCRIPTION
Hello,

I believe that you have 2 bugs in the LSTMCell code.

The first one is the `torch.stack` which, I think, should be `torch.cat` instead. This will create the intended tensor with the dimension of `n_in + n_hid` as mentioned in the book. 

The second one is usage of the `outgate` variable name which is not defined. It should be replaced with the `out` variable which is defined on the above line.

I am providing a custom model implementation based on the `LMModel4` (page 385) so that you can verify the new changes. The data that is fed into this model is exactly the same as the one in the book.

```
class LSTMModel(nn.Module):
    def __init__(self, vocab_sz, n_hidden, bs=64):
        super(LSTMModel, self).__init__()
        self.i_h = nn.Embedding(vocab_sz, n_hidden)
        self.lstm = LSTMCell(n_hidden, n_hidden)
        self.h_o = nn.Linear(n_hidden, vocab_sz)
        self.h = (torch.zeros(bs, n_hidden), torch.zeros(bs, n_hidden))
    
    def forward(self, x):
        outs = []
        for i in range(x.shape[1]):
            res, (h, c) = self.lstm(self.i_h(x[:,i]), self.h)
            outs.append(self.h_o(res))
            self.h = (h, c)
            
        self.h = [h_.detach() for h_ in self.h]
        return torch.stack(outs, dim=1)
    
    def reset(self):
        for h in self.h: h.zero_()

learn = Learner(dls, LSTMModel(len(vocab), 64), loss_func=CrossEntropyLossFlat(), metrics=accuracy, cbs=ModelResetter)
learn.fit_one_cycle(15, 5e-3)
```