### PR TITLE
16_accel_sgd: Fixed average_sqr_grad function

### DIFF
--- a/16_accel_sgd.ipynb
+++ b/16_accel_sgd.ipynb
@@ -746,7 +746,7 @@
    "source": [
     "def average_sqr_grad(p, sqr_mom, sqr_avg=None, **kwargs):\n",
     "    if sqr_avg is None: sqr_avg = torch.zeros_like(p.grad.data)\n",
-    "    return {'sqr_avg': sqr_avg*sqr_mom + p.grad.data**2}"
+    "    return {'sqr_avg': sqr_mom*sqr_avg + (1-sqr_mom)*p.grad.data**2}"
    ]
   },
   {


### PR DESCRIPTION
The 'sqr_avg' returned by the average_sqr_grad function is missing the (1-sqr_mom) term. 
a quick fix. 
cc: @jph00 