### PR TITLE
Fix questionnaire: torch.stack->torch.cat

### DIFF
--- a/09_tabular.ipynb
+++ b/09_tabular.ipynb
@@ -7,7 +7,7 @@
    "outputs": [],
    "source": [
     "#hide\n",
-    "!pip install -Uqq fastbook\n",
+    "!pip install -Uqq fastbook kaggle waterfallcharts treeinterpreter dtreeviz\n",
     "import fastbook\n",
     "fastbook.setup_book()"
    ]
@@ -384,7 +384,7 @@
    ],
    "source": [
     "if not path.exists():\n",
-    "    path.mkdir()\n",
+    "    path.mkdir(parents=true)\n",
     "    api.competition_download_cli('bluebook-for-bulldozers', path=path)\n",
     "    file_extract(path/'bluebook-for-bulldozers.zip')\n",
     "\n",
@@ -1392,7 +1392,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "(path/'to.pkl').save(to)"
+    "save_pickle(path/'to.pkl',to)"
    ]
   },
   {
@@ -1434,7 +1434,7 @@
    "outputs": [],
    "source": [
     "#hide\n",
-    "to = (path/'to.pkl').load()"
+    "to = load_pickle(path/'to.pkl')"
    ]
   },
   {
@@ -9828,31 +9828,6 @@
    "display_name": "Python 3",
    "language": "python",
    "name": "python3"
-  },
-  "language_info": {
-   "codemirror_mode": {
-    "name": "ipython",
-    "version": 3
-   },
-   "file_extension": ".py",
-   "mimetype": "text/x-python",
-   "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.8.5"
-  },
-  "toc": {
-   "base_numbering": 1,
-   "nav_menu": {},
-   "number_sections": false,
-   "sideBar": true,
-   "skip_h1_title": true,
-   "title_cell": "Table of Contents",
-   "title_sidebar": "Contents",
-   "toc_cell": false,
-   "toc_position": {},
-   "toc_section_display": true,
-   "toc_window_display": false
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
#338 fixed a bug in the LSTM cell where torch.cat should be used instead of torch.stack
The questionnaire should be updated too because it refers incorrectly to torch.stack
My very first PR, I hope it's fine!