### PR TITLE
Fix binary_cross_entropy function in 06_multicat.ipynb

### DIFF
--- a/06_multicat.ipynb
+++ b/06_multicat.ipynb
@@ -976,7 +976,7 @@
    "source": [
     "def binary_cross_entropy(inputs, targets):\n",
     "    inputs = inputs.sigmoid()\n",
-    "    return -torch.where(targets==1, inputs, 1-inputs).log().mean()"
+    "    return -torch.where(targets==1, 1-inputs, inputs).log().mean()"
    ]
   },
   {


### PR DESCRIPTION
The order of "inputs" and "1-inputs" is reversed in the "torch.where" call. I also checked against the mnist_loss function in ch4, which has the correct order. Please double check this as I may be mistaken.