### PR TITLE
fix: 13_convolutions.ipynb - we should be normalizing activations

### DIFF
--- a/13_convolutions.ipynb
+++ b/13_convolutions.ipynb
@@ -3415,8 +3415,8 @@
    "source": [
     "def conv(ni, nf, ks=3, act=True):\n",
     "    layers = [nn.Conv2d(ni, nf, stride=2, kernel_size=ks, padding=ks//2)]\n",
-    "    layers.append(nn.BatchNorm2d(nf))\n",
     "    if act: layers.append(nn.ReLU())\n",
+    "    layers.append(nn.BatchNorm2d(nf))\n",
     "    return nn.Sequential(*layers)"
    ]
   },


### PR DESCRIPTION
Hi Jeremy and Sylvain!

First of all, thank you for the great work! The library, the book, and the course are well-written and simply amazing! I, now, recommend your book to everyone who asks me about where to start with AI.

In one of the examples from the chapter 13 we have the following code:

```python
def conv(ni, nf, ks=3, act=True):
    layers = [nn.Conv2d(ni, nf, stride=2, kernel_size=ks, padding=ks//2)]
    layers.append(nn.BatchNorm2d(nf))
    if act: layers.append(nn.ReLU())
    return nn.Sequential(*layers)
```

We have batch norm added before the activation function but the text suggests that we should be normalizing activations.

> Batch normalization (often just called batchnorm) works by taking an average of the mean and standard deviations of the activations of a layer and using those to normalize the activations. However, this can cause problems because the network might want some activations to be really high in order to make accurate predictions. So they also added two learnable parameters (meaning they will be updated in the SGD step), usually called gamma and beta. After normalizing the activations to get some new activation vector y, a batchnorm layer returns gamma*y + beta.

> Try moving the activation function after the batch normalization layer in conv. Does it make a difference? See what you can find out about what order is recommended, and why.

Related: https://github.com/fastai/fastbook/pull/365