### PR TITLE
Fixed incorrect 'content_url' attribute

### DIFF
--- a/02_production.ipynb
+++ b/02_production.ipynb
@@ -367,7 +367,7 @@
    ],
    "source": [
     "results = search_images_bing(key, 'grizzly bear')\n",
-    "ims = results.attrgot('content_url')\n",
+    "ims = results.attrgot('contentUrl')\n",
     "len(ims)"
    ]
   },


### PR DESCRIPTION
In the Bing Image Search API example, when counting results `ims = len(content_url)`, content_url should be `contentUrl`. This is correctly changed further down in the example too when downloading from the actual paths. 