### PR TITLE
fix attrgot contenturl

### DIFF
--- a/02_production.ipynb
+++ b/02_production.ipynb
@@ -367,7 +367,7 @@
    ],
    "source": [
     "results = search_images_bing(key, 'grizzly bear')\n",
-    "ims = results.attrgot('content_url')\n",
+    "ims = results.attrgot('contentUrl')\n",
     "len(ims)"
    ]
   },

--- a/clean/02_production.ipynb
+++ b/clean/02_production.ipynb
@@ -140,7 +140,7 @@
    "outputs": [],
    "source": [
     "results = search_images_bing(key, 'grizzly bear')\n",
-    "ims = results.attrgot('content_url')\n",
+    "ims = results.attrgot('contentUrl')\n",
     "len(ims)"
    ]
   },


### PR DESCRIPTION
The attr is currently wrong.

Response:
`{'webSearchUrl': 'https://www.bing.com/images/search?view=detailv2&FORM=OIIRPO&q=grizzly+bear&id=CB1AF235DF865E3CE2C61B8E5D897386CEC2541C&simid=608025979351991236', 'name': '10 Facts About Grizzly Bears - Some Interesting Facts', 'thumbnailUrl': 'https://tse3.mm.bing.net/th?id=OIP.Ebdz7mQwVEny-uVn3MWrOwHaE8&pid=Api', 'datePublished': '2020-11-22T13:25:00.0000000Z', 'isFamilyFriendly': True, 'contentUrl': 'https://someinterestingfacts.net/wp-content/uploads/2016/07/Canadian-Grizzly-Bear.jpg', 'hostPageUrl': 'https://someinterestingfacts.net/10-facts-grizzly-bear/', 'contentSize': '320188 B', 'encodingFormat': 'jpeg', 'hostPageDisplayUrl': 'https://someinterestingfacts.net/10-facts-grizzly-bear', 'width': 1600, 'height': 1068, 'hostPageDiscoveredDate': '2018-07-15T00:00:00.0000000Z', 'thumbnail': {'width': 474, 'height': 316}, 'imageInsightsToken': 'ccid_Ebdz7mQw*cp_87468A39749C9C4C3F21A32C7BF7D149*mid_CB1AF235DF865E3CE2C61B8E5D897386CEC2541C*simid_608025979351991236*thid_OIP.Ebdz7mQwVEny-uVn3MWrOwHaE8', 'insightsMetadata': {'pagesIncludingCount': 44, 'availableSizesCount': 23}`