### PR TITLE
Fix Azure search response parsing

### DIFF
--- a/02_production.ipynb
+++ b/02_production.ipynb
@@ -367,7 +367,7 @@
    ],
    "source": [
     "results = search_images_bing(key, 'grizzly bear')\n",
-    "ims = results.attrgot('content_url')\n",
+    "ims = results.attrgot('contentUrl')\n",
     "len(ims)"
    ]
   },


### PR DESCRIPTION
In the first image search example the search result is parsed incorrectly as the key needs to be `contentUrl` instead of `content_url.

This may go unnoticed usually as we're not taking a look at the returned urls. `ims` contains a list of 150 Nones.