### PR TITLE
Fixed binary_cross_entropy function

### DIFF
--- a/06_multicat.ipynb
+++ b/06_multicat.ipynb
@@ -976,7 +976,7 @@
    "source": [
     "def binary_cross_entropy(inputs, targets):\n",
     "    inputs = inputs.sigmoid()\n",
-    "    return -torch.where(targets==1, 1-inputs, inputs).log().mean()"
+    "    return -torch.where(targets==1, inputs, 1-inputs).log().mean()"
    ]
   },
   {


### PR DESCRIPTION
The sample function `binary_cross_entropy` should return `sigmoid(inputs[i])` if `target[i] == 1`, and should return `1 - sigmoid(inputs[i])` if `target[i] == 0`.
It should NOT return `1 - sigmoid(inputs[i])` if `target[i] == 1`, and `sigmoid(inputs[i])` if `target[i] == 0`, which is what the code read prior to this commit.

Note that this commit does not change the functionality of the notebook, because the `binary_cross_entropy` function here is only to demonstrate the inner workings of the loss function. The PyTorch function `nn.BCEWithLogitsLoss()` is used instead.