### PR TITLE
Typo: use MSE instead of RMSE

### DIFF
--- a/04_mnist_basics.ipynb
+++ b/04_mnist_basics.ipynb
@@ -3013,7 +3013,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "def mse(preds, targets): return ((preds-targets)**2).mean().sqrt()"
+    "def mse(preds, targets): return ((preds-targets)**2).mean()"
    ]
   },
   {


### PR DESCRIPTION
The implementation of the `mse` function is actually a root means squared error because of the squared root in the end. This PR removes squared root so that the implementation corresponds to the name.