### PR TITLE
Add vietnamese language at README_vn.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/fastai/fastbook/master)  
-[English](./README.md) / [Spanish](./README_es.md) / [Korean](./README_ko.md) / [Chinese](./README_zh.md) / [Bengali](./README_bn.md) / [Indonesian](./README_id.md)
+[English](./README.md) / [Spanish](./README_es.md) / [Korean](./README_ko.md) / [Chinese](./README_zh.md) / [Bengali](./README_bn.md) / [Indonesian](./README_id.md) / [Vietnamese](./README_vn.md)
 
 # The fastai book
 

--- a/README_vn.md
+++ b/README_vn.md
@@ -3,19 +3,19 @@
 
 # Cuốn sách fastai
 
-Những notebooks này giới thiệu về học sâu, sử dụng [fastai] (https://docs.fast.ai/) và [PyTorch] (https://pytorch.org/). Fastai là một thư viện API cho học sâu;  để biết thêm thông tin, hãy xem [fastai paper] (https://www.mdpi.com/2078-2489/11/2/108). Mọi tài liệu trong repo này thuộc bản quyền của Jeremy Howard và Sylvain Gugger, từ năm 2020 trở đi.
+Những notebooks này giới thiệu về học sâu, sử dụng [fastai](https://docs.fast.ai/) và [PyTorch](https://pytorch.org/). Fastai là một thư viện API cho học sâu;  để biết thêm thông tin, hãy xem [fastai paper](https://www.mdpi.com/2078-2489/11/2/108). Mọi tài liệu trong repo này thuộc bản quyền của Jeremy Howard và Sylvain Gugger, từ năm 2020 trở đi.
 
-Những notebooks này được sử dụng cho khóa học online mở [a MOOC] (https://course.fast.ai) và là nội dung cơ bản của cuốn [sách này] (https://www.amazon.com/Deep-Learning-Coders-fastai-PyTorch/dp/1492045527), hiện bạn có thể đặt mua. Cuốn sách này không có các hạn chế GPL giống như trong bản notebooks ở repo này.
+Các notebooks được sử dụng cho khóa học online mở [a MOOC](https://course.fast.ai) và là nội dung cơ bản của cuốn [sách này](https://www.amazon.com/Deep-Learning-Coders-fastai-PyTorch/dp/1492045527), và hiện bạn có thể đặt mua. Cuốn sách này không có các hạn chế GPL giống như trong bản notebooks ở repo này.
 
-Mã code trong các notebooks và file python `.py` được đăng ký giấy phép GPL v3; chi tiết xem tại file LICENSE.
+Mã nguồn trong các notebooks và file python `.py` được đăng ký giấy phép GPL v3; chi tiết xem tại file LICENSE.
 
-Phần còn lại (bao gồm tất cả các markdown cells trong các notebooks và nội dung khác) không được phép phân phối hoặc thay đổi định dạng hoặc phương tiện nào. Trừ trường hợp, bản sao của notebooks hoặc forking của notebooks này cho mục đích sử dụng cá nhân. Không được phép sử dụng notebooks cho mục đích thương mại hoặc quảng bá. Chúng tôi cung cấp miễn phí những tài liệu này để giúp bạn học về học sâu, vì vậy hãy tôn trọng bản quyền của chúng tôi và những hạn chế này.
+Những phần còn lại (bao gồm tất cả các markdown cells trong các notebooks cùng các nội dung khác) không được phép phân phối hoặc thay đổi định dạng hoặc phương tiện nào. Trừ trường hợp, bản sao của notebooks hoặc forking của notebooks này cho mục đích sử dụng cá nhân. Không được phép sử dụng notebooks cho mục đích thương mại hoặc quảng bá. Chúng tôi cung cấp miễn phí những tài liệu này để giúp bạn học về học sâu, vì vậy hãy tôn trọng bản quyền của chúng tôi và những hạn chế này.
 
 Nếu bạn thấy ai đó lưu trữ bản sao của những tài liệu này ở một nơi khác, vui lòng cho họ biết rằng hành động của họ là không được phép và có thể dẫn đến hành động pháp lý. Hơn nữa, chúng sẽ gây tổn hại cho cộng đồng vì chúng tôi không có khả năng sẽ không tiếp tục phát hành tài liệu bổ sung theo cách này nếu mọi người bỏ qua bản quyền của chúng tôi.
 
-Đây là một bản thảo draft. Nếu bạn gặp khó khăn khi chạy các notebooks, vui lòng tìm kiếm tại [diễn đàn fastai-dev] (https://forums.fast.ai/c/fastai-users/fastai-dev/) để có câu trả lời và yêu cầu trợ giúp nếu cần. Vui lòng không sử dụng GitHub cho các sự cố (issues) khi chạy notebooks.
+Đây là một bản thảo draft. Nếu bạn gặp khó khăn khi chạy các notebooks, vui lòng tìm kiếm câu trả lời và yêu cầu trợ giúp nếu cần tại [diễn đàn fastai-dev](https://forums.fast.ai/c/fastai-users/fastai-dev/). Vui lòng không sử dụng GitHub cho các lỗi (issues) khi chạy notebooks.
 
-Nếu bạn thực hiện bất kỳ pull requests nào đối với repo này, thì bạn đang chuyển nhượng bản quyền của nội dung đó cho Jeremy Howard và Sylvain Gugger. (Ngoài ra, nếu bạn thực hiện các chỉnh sửa nhỏ về chính tả hoặc văn bản, vui lòng nêu rõ tên của tệp file và mô tả rất ngắn gọn về những gì bạn đang sửa. Bởi vì rất khó để reviewers biết bạn đã sửa những nơi nào. Xin cảm ơn.)
+Nếu bạn thực hiện bất kỳ pull requests nào đối với repo này, thì bạn đang chuyển nhượng bản quyền của nội dung đó cho Jeremy Howard và Sylvain Gugger. (Ngoài ra, nếu bạn thực hiện các chỉnh sửa nhỏ như về lỗi chính tả, vui lòng nêu rõ tên của tệp file văn bản và mô tả rất ngắn gọn về những gì bạn đang sửa. Bởi vì rất khó để reviewers biết bạn đã sửa những nơi nào. Xin cảm ơn!)
 
 ## Trích dẫn
 

--- a/README_vn.md
+++ b/README_vn.md
@@ -1,0 +1,33 @@
+[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/fastai/fastbook/master)  
+[English](./README.md) / [Spanish](./README_es.md) / [Korean](./README_ko.md) / [Chinese](./README_zh.md) / [Bengali](./README_bn.md) / [Indonesian](./README_id.md) / [Vietnamese](./README_vn.md)
+
+# Cuốn sách fastai
+
+Những notebooks này giới thiệu về học sâu, sử dụng [fastai] (https://docs.fast.ai/) và [PyTorch] (https://pytorch.org/). Fastai là một thư viện API cho học sâu;  để biết thêm thông tin, hãy xem [fastai paper] (https://www.mdpi.com/2078-2489/11/2/108). Mọi tài liệu trong repo này thuộc bản quyền của Jeremy Howard và Sylvain Gugger, từ năm 2020 trở đi.
+
+Những notebooks này được sử dụng cho khóa học online mở [a MOOC] (https://course.fast.ai) và là nội dung cơ bản của cuốn [sách này] (https://www.amazon.com/Deep-Learning-Coders-fastai-PyTorch/dp/1492045527), hiện bạn có thể đặt mua. Cuốn sách này không có các hạn chế GPL giống như trong bản notebooks ở repo này.
+
+Mã code trong các notebooks và file python `.py` được đăng ký giấy phép GPL v3; chi tiết xem tại file LICENSE.
+
+Phần còn lại (bao gồm tất cả các markdown cells trong các notebooks và nội dung khác) không được phép phân phối hoặc thay đổi định dạng hoặc phương tiện nào. Trừ trường hợp, bản sao của notebooks hoặc forking của notebooks này cho mục đích sử dụng cá nhân. Không được phép sử dụng notebooks cho mục đích thương mại hoặc quảng bá. Chúng tôi cung cấp miễn phí những tài liệu này để giúp bạn học về học sâu, vì vậy hãy tôn trọng bản quyền của chúng tôi và những hạn chế này.
+
+Nếu bạn thấy ai đó lưu trữ bản sao của những tài liệu này ở một nơi khác, vui lòng cho họ biết rằng hành động của họ là không được phép và có thể dẫn đến hành động pháp lý. Hơn nữa, chúng sẽ gây tổn hại cho cộng đồng vì chúng tôi không có khả năng sẽ không tiếp tục phát hành tài liệu bổ sung theo cách này nếu mọi người bỏ qua bản quyền của chúng tôi.
+
+Đây là một bản thảo draft. Nếu bạn gặp khó khăn khi chạy các notebooks, vui lòng tìm kiếm tại [diễn đàn fastai-dev] (https://forums.fast.ai/c/fastai-users/fastai-dev/) để có câu trả lời và yêu cầu trợ giúp nếu cần. Vui lòng không sử dụng GitHub cho các sự cố (issues) khi chạy notebooks.
+
+Nếu bạn thực hiện bất kỳ pull requests nào đối với repo này, thì bạn đang chuyển nhượng bản quyền của nội dung đó cho Jeremy Howard và Sylvain Gugger. (Ngoài ra, nếu bạn thực hiện các chỉnh sửa nhỏ về chính tả hoặc văn bản, vui lòng nêu rõ tên của tệp file và mô tả rất ngắn gọn về những gì bạn đang sửa. Bởi vì rất khó để reviewers biết bạn đã sửa những nơi nào. Xin cảm ơn.)
+
+## Trích dẫn
+
+Nếu bạn muốn trích dẫn cuốn sách, bạn có thể sử dụng như sau:
+
+```
+@book{howard2020deep,
+title={Deep Learning for Coders with Fastai and Pytorch: AI Applications Without a PhD},
+author={Howard, J. and Gugger, S.},
+isbn={9781492045526},
+url={https://books.google.no/books?id=xd6LxgEACAAJ},
+year={2020},
+publisher={O'Reilly Media, Incorporated}
+}
+```


### PR DESCRIPTION
I would like to add the vietnamese language for README at README_vn.md. This file is the transalation of README.md, from english to vietnamese. 

A header [Vietnamese](./README_vn.md) is alse added into the first paragraph of README.md to link to the vietnamse file.

Thanks.