### PR TITLE
Fixing os import and bing search result response parameter

### DIFF
--- a/clean/02_production.ipynb
+++ b/clean/02_production.ipynb
@@ -121,6 +121,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "import os\n",
     "key = os.environ.get('AZURE_SEARCH_KEY', 'XXX')"
    ]
   },
@@ -140,7 +141,7 @@
    "outputs": [],
    "source": [
     "results = search_images_bing(key, 'grizzly bear')\n",
-    "ims = results.attrgot('content_url')\n",
+    "ims = results.attrgot('contentUrl')\n",
     "len(ims)"
    ]
   },


### PR DESCRIPTION
File name: `clean/02_production.ipynb`
Change description:
1. Importing os to read the Azure key environment variable
2. Correcting the contentUrl response parameter while reading the response from Bing image search