### PR TITLE
Fix matrix calculation in Chapter 13

### DIFF
--- a/13_convolutions.ipynb
+++ b/13_convolutions.ipynb
@@ -1341,7 +1341,7 @@
     "\n",
     "$$\\begin{matrix} a1 & a2 & a3 \\\\ a4 & a5 & a6 \\\\ a7 & a8 & a9 \\end{matrix}$$\n",
     "\n",
-    "it will return $a1+a2+a3-a7-a8-a9$. If we are in a part of the image where $a1$, $a2$, and $a3$ add up to the same as $a7$, $a8$, and $a9$, then the terms will cancel each other out and we will get 0. However, if $a1$ is greater than $a7$, $a2$ is greater than $a8$, and $a3$ is greater than $a9$, we will get a bigger number as a result. So this filter detects horizontal edges—more precisely, edges where we go from bright parts of the image at the top to darker parts at the bottom.\n",
+    "it will return $-a1-a2-a3+a7+a8+a9$. If we are in a part of the image where $a1$, $a2$, and $a3$ add up to the same as $a7$, $a8$, and $a9$, then the terms will cancel each other out and we will get 0. However, if $a7$ is greater than $a1$, $a8$ is greater than $a2$, and $a9$ is greater than $a3$, we will get a bigger number as a result. So this filter detects horizontal edges—more precisely, edges where we go from bright parts of the image at the top to darker parts at the bottom.\n",
     "\n",
     "Changing our filter to have the row of `1`s at the top and the `-1`s at the bottom would detect horizontal edges that go from dark to light. Putting the `1`s and `-1`s in columns versus rows would give us filters that detect vertical edges. Each set of weights will produce a different kind of outcome.\n",
     "\n",


### PR DESCRIPTION
The example convolution calculation in Chapter 13 (see below) is wrong. 

<img width="1130" alt="Screenshot 2021-04-24 at 19 37 31" src="https://user-images.githubusercontent.com/48474650/115955904-8436d300-a534-11eb-9975-6e1f4e31e302.png">

The kernel being referred to in this example is instantiated earlier as such:
``` python
top_edge = tensor([[-1,-1,-1],[0,0,0],[1,1,1]]).float()
```

Therefore the correct sum would be -a1-a2-a3+a7+a8+a9. This PR addresses this.