### PR TITLE
Add Open in Kaggle Badge

### DIFF
--- a/04_mnist_basics.ipynb
+++ b/04_mnist_basics.ipynb
@@ -1,6 +1,13 @@
 {
  "cells": [
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<a href=\"https://kaggle.com/kernels/welcome?src=https://github.com/fastai/fastbook/blob/master/04_mnist_basics.ipynb\"><img align=\"left\" alt=\"Kaggle\" title=\"Open in Kaggle\" src=\"https://kaggle.com/static/images/open-in-kaggle.svg\"></a>"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},


### PR DESCRIPTION
This is an example of what adding a Kaggle Badge (that allows for opening the .ipynb as a Kaggle Notebook as seen here https://www.kaggle.com/product-feedback/152480) would look like.

If it makes sense I can submit a further PR adding it to the other notebooks in fastbook.