### PR TITLE
Fix graphviz dependency and widgets import

### DIFF
--- a/01_intro.ipynb
+++ b/01_intro.ipynb
@@ -9,7 +9,7 @@
     "#hide\n",
     "!pip install -Uqq fastbook graphviz\n",
     "import fastbook\n",
-    "import ipywidgets as widgets\n",
+    "import ipywidgets as widgets\n\n",
     "fastbook.setup_book()"
    ]
   },

--- a/01_intro.ipynb
+++ b/01_intro.ipynb
@@ -7,8 +7,9 @@
    "outputs": [],
    "source": [
     "#hide\n",
-    "!pip install -Uqq fastbook\n",
+    "!pip install -Uqq fastbook graphviz\n",
     "import fastbook\n",
+    "import ipywidgets as widgets\n",
     "fastbook.setup_book()"
    ]
   },

--- a/clean/01_intro.ipynb
+++ b/clean/01_intro.ipynb
@@ -9,7 +9,7 @@
     "#hide\n",
     "!pip install -Uqq fastbook graphviz\n",
     "import fastbook\n",
-    "import ipywidgets as widgets\n",
+    "import ipywidgets as widgets\n\n",
     "fastbook.setup_book()"
    ]
   },

--- a/clean/01_intro.ipynb
+++ b/clean/01_intro.ipynb
@@ -7,8 +7,9 @@
    "outputs": [],
    "source": [
     "#hide\n",
-    "!pip install -Uqq fastbook\n",
+    "!pip install -Uqq fastbook graphviz\n",
     "import fastbook\n",
+    "import ipywidgets as widgets\n",
     "fastbook.setup_book()"
    ]
   },


### PR DESCRIPTION
First import shows errors when running the cell on a local machine, takes time to go through forums and find a fix which may frustrate newcomers early in the course. This fixes the issue and is working on current latest rolling release of Arch Linux which includes latest Python (3.9.5) and Pip (20.3.1)