### PR TITLE
Revert "04_mnist_basics: MSE lacks .sqrt() (#327)"

### DIFF
--- a/04_mnist_basics.ipynb
+++ b/04_mnist_basics.ipynb
@@ -3013,7 +3013,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "def mse(preds, targets): return ((preds-targets)**2).mean().sqrt()"
+    "def mse(preds, targets): return ((preds-targets)**2).mean()"
    ]
   },
   {


### PR DESCRIPTION
This reverts commit 665c2384677aa1d42a364e93f8edcfea2ee71bc5 and PR #327.

The PR being reverted is incorrect since the original code contained the correct definition of MSE. Adding the `sqrt()` changes it to RMSE with the knock on effect being the loss is much smaller and the resulting parameter updates becoming negligible. See below of what the prediction plots in Step 6 become vs what they should be (i.e. the original plots still in the notebook)

Plot when using MSE with `.sqrt()` (i.e. the RMSE)
![image](https://user-images.githubusercontent.com/7526106/120113213-c679b280-c179-11eb-94db-a6460f9a02ff.png)

Original with correct definition of MSE
![image](https://user-images.githubusercontent.com/7526106/120113232-d85b5580-c179-11eb-89fe-7c09e3a2eaba.png)

Also should I manually update the clean notebook as well? Or does that happen automatically somewhere else?