### PR TITLE
Correct ch.4 MNIST: set threshold to 0.0 when not using sigmoid

### DIFF
--- a/04_mnist_basics.ipynb
+++ b/04_mnist_basics.ipynb
@@ -3859,7 +3859,7 @@
     }
    ],
    "source": [
-    "corrects = (preds>0.5).float() == train_y\n",
+    "corrects = (preds>0.0).float() == train_y\n",
     "corrects"
    ]
   },

--- a/04_mnist_basics.ipynb
+++ b/04_mnist_basics.ipynb
@@ -3833,7 +3833,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Let's check our accuracy. To decide if an output represents a 3 or a 7, we can just check whether it's greater than 0.5, so our accuracy for each item can be calculated (using broadcasting, so no loops!) with:"
+    "Let's check our accuracy. To decide if an output represents a 3 or a 7, we can just check whether it's greater than 0.0, so our accuracy for each item can be calculated (using broadcasting, so no loops!) with:"
    ]
   },
   {


### PR DESCRIPTION
In chapter 4 about MNIST, there's an error in the book, which is not apparent in the cleaned notebook. Before the introduction of the sigmoid function, the threshold on the linear outputs is set to `0.5` instead of `0.0`.