### PR TITLE
Bug fix for RNN hidden state

### DIFF
--- a/12_nlp_dive.ipynb
+++ b/12_nlp_dive.ipynb
@@ -777,6 +777,7 @@
     "            self.h = F.relu(self.h_h(self.h))\n",
     "        out = self.h_o(self.h)\n",
     "        self.h = self.h.detach()\n",
+    "        self.h = self.h.mean(0)\n",
     "        return out\n",
     "    \n",
     "    def reset(self): self.h = 0"
@@ -1096,6 +1097,7 @@
     "            self.h = F.relu(self.h_h(self.h))\n",
     "            outs.append(self.h_o(self.h))\n",
     "        self.h = self.h.detach()\n",
+    "        self.h = self.h.mean(0)\n",
     "        return torch.stack(outs, dim=1)\n",
     "    \n",
     "    def reset(self): self.h = 0"
@@ -2358,8 +2360,20 @@
    "display_name": "Python 3",
    "language": "python",
    "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.2"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }

--- a/clean/12_nlp_dive.ipynb
+++ b/clean/12_nlp_dive.ipynb
@@ -279,6 +279,7 @@
     "            self.h = F.relu(self.h_h(self.h))\n",
     "        out = self.h_o(self.h)\n",
     "        self.h = self.h.detach()\n",
+    "        self.h = self.h.mean(0)\n",
     "        return out\n",
     "    \n",
     "    def reset(self): self.h = 0"
@@ -382,6 +383,7 @@
     "            self.h = F.relu(self.h_h(self.h))\n",
     "            outs.append(self.h_o(self.h))\n",
     "        self.h = self.h.detach()\n",
+    "        self.h = self.h.mean(0)\n",
     "        return torch.stack(outs, dim=1)\n",
     "    \n",
     "    def reset(self): self.h = 0"
@@ -773,8 +775,20 @@
    "display_name": "Python 3",
    "language": "python",
    "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.2"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }


### PR DESCRIPTION
In the current state of the code of RNN is:
```
class LMModel3(Module):
    def __init__(self, vocab_sz, n_hidden):
        self.i_h = nn.Embedding(vocab_sz, n_hidden)  
        self.h_h = nn.Linear(n_hidden, n_hidden)     
        self.h_o = nn.Linear(n_hidden,vocab_sz)
        self.h = 0
        
    def forward(self, x):
        for i in range(3):
            self.h = self.h + self.i_h(x[:,i])
            self.h = F.relu(self.h_h(self.h))
        out = self.h_o(self.h)
        self.h = self.h.detach()
        return out
    
    def reset(self): self.h = 0
```

If we analyze the shape of Tensor: ```self.h``` it will be of shape ```[batch_size, n_hidden]``` and this causes issues when the shape of the last batch of the dataset when it is different from the rest of the batch size. Also as per our understanding, the shape of the 
![RNN_hidden](https://user-images.githubusercontent.com/13318820/133253672-f0bab3bd-c97c-478d-8432-1268a425a40b.png)
hidden state should be ```[n_hidden]```. In order to correct the same, we should take the mean of `self.h` across the batch size which is ```self.h = self.h.mean(0)``` just before the return statement.