### PR TITLE
04_mnist_basics.ipynb error update

### DIFF
--- a/04_mnist_basics.ipynb
+++ b/04_mnist_basics.ipynb
@@ -3896,7 +3896,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "weights[0] *= 1.0001"
+    "weights[0].data *= 1.0001"
    ]
   },
   {


### PR DESCRIPTION
weights[0] *= 1.0001
---------------------------------------------------------------------------
RuntimeError                              Traceback (most recent call last)
<ipython-input-129-2a9b9601ff3d> in <module>()
----> 1 weights[0] *= 1.0001

RuntimeError: a view of a leaf Variable that requires grad is being used in an in-place operation.

update
 -> weights[0].data *= 1.0001