### PR TITLE
Mnist_basics notebook - removed square root from `mse` function

### DIFF
--- a/04_mnist_basics.ipynb
+++ b/04_mnist_basics.ipynb
@@ -3013,7 +3013,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "def mse(preds, targets): return ((preds-targets)**2).mean().sqrt()"
+    "def mse(preds, targets): return ((preds-targets)**2).mean()"
    ]
   },
   {


### PR DESCRIPTION
Going from the `04_mnist_basics.ipynb` I can across a wrongly defined `mse` function, which was
```
def mse(preds, targets): return ((preds-targets)**2).mean().sqrt()
```
Apparently, it was implemented as RMSE. Thus, I removed squared root.
