### PR TITLE
Update 05_pet_breeds.ipynb

### DIFF
--- a/05_pet_breeds.ipynb
+++ b/05_pet_breeds.ipynb
@@ -1158,7 +1158,7 @@
     "df = pd.DataFrame(sm_acts, columns=[\"3\",\"7\"])\n",
     "df['targ'] = targ\n",
     "df['idx'] = idx\n",
-    "df['loss'] = sm_acts[range(6), targ]\n",
+    "df['loss'] = -sm_acts[range(6), targ]\n",
     "t = df.style.hide_index()\n",
     "#To have html code compatible with our script\n",
     "html = t._repr_html_().split('</style>')[1]\n",


### PR DESCRIPTION
There should be a negative sign here for the following reason:

Take targ[0] as an example. Because targ[0] is 0, when sm_acts[0,0] is high, the prediction shows it is very much a 0, so the loss should be low. Therefore, the higher sm_acts[0,0] is, the lower the loss is. Same when targ[i] is 1.

Behind the scene, CrossEntropyLoss has an extra log. so it is sm_acts[idx, targ].log()*(-1). This can be verified when we compute sm_acts[idx, targ].log()*(-1) == nn.CrossEntropyLoss(reduction='none')(acts, targ). Notice '*(-1)' after taking the log, and log itself is monotonic, so higher result gives higher loss, and without the negative, higher result will give lower loss, which is incorrect.