### PR TITLE
Update binary_cross_entropy  in 06_multicat.ipynb

### DIFF
--- a/06_multicat.ipynb
+++ b/06_multicat.ipynb
@@ -976,7 +976,7 @@
    "source": [
     "def binary_cross_entropy(inputs, targets):\n",
     "    inputs = inputs.sigmoid()\n",
-    "    return -torch.where(targets==1, 1-inputs, inputs).log().mean()"
+    "    return -torch.where(targets==1, inputs, 1-inputs).log().mean()"
    ]
   },
   {


### PR DESCRIPTION
The same notebook under clean directory has the right implementation. This notebook need to be corrected by changing from 
```return -torch.where(targets==1, 1-inputs, inputs).log().mean()```
to
```return -torch.where(targets==1, inputs, 1-inputs).log().mean()```
