### PR TITLE
Removed invalid URI

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -9,4 +9,4 @@ dependencies:
   - torchvision
   - pip
   - pip:
-    - -r file:requirements.txt
+    - -r requirements.txt


### PR DESCRIPTION
Installing a Conda environment 'Conda env create -f environment.yml' fails due to a change in the Pip code.  This has resulted in a change to valid URI syntax.  Therefore, file:requirements.txt is no longer valid syntax and 'file:' has been dropped. 

