### PR TITLE
Bugfix on 05_pet_breeds lr_min, lr_steep example

### DIFF
--- a/05_pet_breeds.ipynb
+++ b/05_pet_breeds.ipynb
@@ -1655,7 +1655,7 @@
    ],
    "source": [
     "learn = cnn_learner(dls, resnet34, metrics=error_rate)\n",
-    "lr_min,lr_steep = learn.lr_find()"
+    "lr_min,lr_steep = learn.lr_find(suggest_funcs = (minimum, steep))"
    ]
   },
   {


### PR DESCRIPTION
Fix ValueError when assigning lr_min, lr_steep values. It appears default behavior now is to only return lr_valley. Need to add suggest_funcs arg for minimum and steep instead.