### PR TITLE
environment.yml: Pin torchvision

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -6,7 +6,7 @@ channels:
 dependencies:
   - python>=3.6
   - pytorch>=1.6
-  - torchvision
+  - torchvision=0.11.3
   - pip
   - pip:
     - -r file:requirements.txt


### PR DESCRIPTION
Pins torchvision to 0.11.3 since the latest 0.12.0 version throws an exception `ImportError: cannot import name QuantStub from torch.ao.quantization torch/ao/quantization/__init__.py` when running `from fastbook import *`