### PR TITLE
fixed ordered timeseries train/valid split in 09_tabular

### DIFF
--- a/09_tabular.ipynb
+++ b/09_tabular.ipynb
@@ -14,7 +14,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "metadata": {
     "hide_input": false
    },
@@ -415,7 +415,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -424,7 +424,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [
     {
@@ -446,7 +446,7 @@
        "      dtype='object')"
       ]
      },
-     "execution_count": 9,
+     "execution_count": 4,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -466,7 +466,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [
     {
@@ -475,7 +475,7 @@
        "array([nan, 'Medium', 'Small', 'Large / Medium', 'Mini', 'Large', 'Compact'], dtype=object)"
       ]
      },
-     "execution_count": 10,
+     "execution_count": 5,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -493,7 +493,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -502,7 +502,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -521,7 +521,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 8,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -530,7 +530,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 9,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -615,7 +615,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 10,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -631,7 +631,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 11,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -648,16 +648,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 12,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "'saleWeek saleYear saleMonth saleDay saleDayofweek saleDayofyear saleIs_month_end saleIs_month_start saleIs_quarter_end saleIs_quarter_start saleIs_year_end saleIs_year_start saleElapsed'"
+       "'saleYear saleMonth saleWeek saleDay saleDayofweek saleDayofyear saleIs_month_end saleIs_month_start saleIs_quarter_end saleIs_quarter_start saleIs_year_end saleIs_year_start saleElapsed'"
       ]
      },
-     "execution_count": 17,
+     "execution_count": 12,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -694,7 +694,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 13,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -720,14 +720,50 @@
   },
   {
    "cell_type": "code",
+   "execution_count": 14,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "valid_cond = (df.saleYear==2012) | ((df.saleYear==2011) & (df.saleMonth==12))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "train_idx = np.where(~valid_cond)[0]\n",
+    "valid_idx = np.where( valid_cond)[0]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "array(['2011-12', '2012-1', '2012-2', '2012-3', '2012-4'], dtype=object)"
+      ]
+     },
+     "execution_count": 16,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# Check validation date\n",
+    "(df.loc[valid_idx,:].saleYear.astype(str) + '-' + df.loc[valid_idx,:].saleMonth.astype(str)).unique()"
+   ]
+  },
+  {
+   "cell_type": "code",
    "execution_count": 19,
    "metadata": {},
    "outputs": [],
    "source": [
-    "cond = (df.saleYear<2011) | (df.saleMonth<10)\n",
-    "train_idx = np.where( cond)[0]\n",
-    "valid_idx = np.where(~cond)[0]\n",
-    "\n",
     "splits = (list(train_idx),list(valid_idx))"
    ]
   },
@@ -9485,9 +9521,7 @@
   {
    "cell_type": "code",
    "execution_count": 112,
-   "metadata": {
-    "scrolled": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "procs_nn = [Categorify, FillMissing, Normalize]\n",
@@ -10016,7 +10050,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.7"
+   "version": "3.8.12"
   },
   "toc": {
    "base_numbering": 1,


### PR DESCRIPTION
Problem: in the original notebook, the splitting rule results in incorrect train/valid set.
Fix: added conditions for splitting + test
 
![image](https://user-images.githubusercontent.com/86608643/158594799-cb521561-e7e0-4820-9c4b-c45740b118d5.png)
