### PR TITLE
Fix missing import for json module

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -5,6 +5,8 @@ from ipywidgets import widgets
 from pandas.api.types import CategoricalDtype
 
 import matplotlib as mpl
+import json
+
 # mpl.rcParams['figure.dpi']= 200
 mpl.rcParams['savefig.dpi']= 200
 mpl.rcParams['font.size']=12


### PR DESCRIPTION
json module is used in ddg search and so that method fails since json module is not imported