### PR TITLE
binary cross entropy formula have inputs and 1-inputs reversed

### DIFF
--- a/06_multicat.ipynb
+++ b/06_multicat.ipynb
@@ -976,7 +976,7 @@
    "source": [
     "def binary_cross_entropy(inputs, targets):\n",
     "    inputs = inputs.sigmoid()\n",
-    "    return -torch.where(targets==1, inputs, 1-inputs).log().mean()"
+    "    return -torch.where(targets==1, 1-inputs, inputs).log().mean()"
    ]
   },
   {
@@ -2240,6 +2240,18 @@
    "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.10"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Binary cross entropy formula, in notebook Chapter 6, seems to have `inputs` and `1-inputs` reversed : 

```
def binary_cross_entropy(inputs, targets):
    inputs = inputs.sigmoid()
    return -torch.where(targets==1, inputs, 1-inputs).log().mean()

```
The book, "Deep Learning for Coders with fastai and PyTorch", is showing the correct formula though, as shown below.
![book](https://user-images.githubusercontent.com/69753975/170722045-d0f2db5e-c0ab-4a71-954e-fdff25f7120a.jpg)
