### PR TITLE
Reference for downloading images using the Duckduckgo function has been added. 

### DIFF
--- a/02_production.ipynb
+++ b/02_production.ipynb
@@ -2,19 +2,100 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 6,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "'[' is not recognized as an internal or external command,\n",
+      "operable program or batch file.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Requirement already satisfied: fastai in c:\\users\\raajas\\appdata\\local\\programs\\python\\python310\\lib\\site-packages (2.6.3)\n",
+      "Requirement already satisfied: pip in c:\\users\\raajas\\appdata\\local\\programs\\python\\python310\\lib\\site-packages (from fastai) (22.0.4)\n",
+      "Requirement already satisfied: pandas in c:\\users\\raajas\\appdata\\local\\programs\\python\\python310\\lib\\site-packages (from fastai) (1.4.2)\n",
+      "Requirement already satisfied: fastdownload<2,>=0.0.5 in c:\\users\\raajas\\appdata\\local\\programs\\python\\python310\\lib\\site-packages (from fastai) (0.0.6)\n",
+      "Requirement already satisfied: fastcore<1.5,>=1.3.27 in c:\\users\\raajas\\appdata\\local\\programs\\python\\python310\\lib\\site-packages (from fastai) (1.4.3)\n",
+      "Requirement already satisfied: packaging in c:\\users\\raajas\\appdata\\local\\programs\\python\\python310\\lib\\site-packages (from fastai) (21.3)\n",
+      "Requirement already satisfied: scipy in c:\\users\\raajas\\appdata\\local\\programs\\python\\python310\\lib\\site-packages (from fastai) (1.8.1)\n",
+      "Requirement already satisfied: requests in c:\\users\\raajas\\appdata\\local\\programs\\python\\python310\\lib\\site-packages (from fastai) (2.27.1)\n",
+      "Requirement already satisfied: scikit-learn in c:\\users\\raajas\\appdata\\local\\programs\\python\\python310\\lib\\site-packages (from fastai) (1.1.1)\n",
+      "Requirement already satisfied: pillow>6.0.0 in c:\\users\\raajas\\appdata\\local\\programs\\python\\python310\\lib\\site-packages (from fastai) (9.1.1)\n",
+      "Requirement already satisfied: fastprogress>=0.2.4 in c:\\users\\raajas\\appdata\\local\\programs\\python\\python310\\lib\\site-packages (from fastai) (1.0.2)\n",
+      "Requirement already satisfied: torch<1.12,>=1.7.0 in c:\\users\\raajas\\appdata\\local\\programs\\python\\python310\\lib\\site-packages (from fastai) (1.11.0)\n",
+      "Requirement already satisfied: torchvision>=0.8.2 in c:\\users\\raajas\\appdata\\local\\programs\\python\\python310\\lib\\site-packages (from fastai) (0.12.0)\n",
+      "Requirement already satisfied: spacy<4 in c:\\users\\raajas\\appdata\\local\\programs\\python\\python310\\lib\\site-packages (from fastai) (3.3.0)\n",
+      "Requirement already satisfied: pyyaml in c:\\users\\raajas\\appdata\\local\\programs\\python\\python310\\lib\\site-packages (from fastai) (6.0)\n",
+      "Requirement already satisfied: matplotlib in c:\\users\\raajas\\appdata\\local\\programs\\python\\python310\\lib\\site-packages (from fastai) (3.5.2)\n",
+      "Requirement already satisfied: cymem<2.1.0,>=2.0.2 in c:\\users\\raajas\\appdata\\local\\programs\\python\\python310\\lib\\site-packages (from spacy<4->fastai) (2.0.6)\n",
+      "Requirement already satisfied: blis<0.8.0,>=0.4.0 in c:\\users\\raajas\\appdata\\local\\programs\\python\\python310\\lib\\site-packages (from spacy<4->fastai) (0.7.7)\n",
+      "Requirement already satisfied: jinja2 in c:\\users\\raajas\\appdata\\local\\programs\\python\\python310\\lib\\site-packages (from spacy<4->fastai) (3.1.2)\n",
+      "Requirement already satisfied: spacy-legacy<3.1.0,>=3.0.9 in c:\\users\\raajas\\appdata\\local\\programs\\python\\python310\\lib\\site-packages (from spacy<4->fastai) (3.0.9)\n",
+      "Requirement already satisfied: numpy>=1.15.0 in c:\\users\\raajas\\appdata\\local\\programs\\python\\python310\\lib\\site-packages (from spacy<4->fastai) (1.22.4)\n",
+      "Requirement already satisfied: setuptools in c:\\users\\raajas\\appdata\\local\\programs\\python\\python310\\lib\\site-packages (from spacy<4->fastai) (58.1.0)\n",
+      "Requirement already satisfied: pathy>=0.3.5 in c:\\users\\raajas\\appdata\\local\\programs\\python\\python310\\lib\\site-packages (from spacy<4->fastai) (0.6.1)\n",
+      "Requirement already satisfied: thinc<8.1.0,>=8.0.14 in c:\\users\\raajas\\appdata\\local\\programs\\python\\python310\\lib\\site-packages (from spacy<4->fastai) (8.0.17)\n",
+      "Requirement already satisfied: murmurhash<1.1.0,>=0.28.0 in c:\\users\\raajas\\appdata\\local\\programs\\python\\python310\\lib\\site-packages (from spacy<4->fastai) (1.0.7)\n",
+      "Requirement already satisfied: typer<0.5.0,>=0.3.0 in c:\\users\\raajas\\appdata\\local\\programs\\python\\python310\\lib\\site-packages (from spacy<4->fastai) (0.4.1)\n",
+      "Requirement already satisfied: langcodes<4.0.0,>=3.2.0 in c:\\users\\raajas\\appdata\\local\\programs\\python\\python310\\lib\\site-packages (from spacy<4->fastai) (3.3.0)\n",
+      "Requirement already satisfied: tqdm<5.0.0,>=4.38.0 in c:\\users\\raajas\\appdata\\local\\programs\\python\\python310\\lib\\site-packages (from spacy<4->fastai) (4.64.0)\n",
+      "Requirement already satisfied: pydantic!=1.8,!=1.8.1,<1.9.0,>=1.7.4 in c:\\users\\raajas\\appdata\\local\\programs\\python\\python310\\lib\\site-packages (from spacy<4->fastai) (1.8.2)\n",
+      "Requirement already satisfied: spacy-loggers<2.0.0,>=1.0.0 in c:\\users\\raajas\\appdata\\local\\programs\\python\\python310\\lib\\site-packages (from spacy<4->fastai) (1.0.2)\n",
+      "Requirement already satisfied: preshed<3.1.0,>=3.0.2 in c:\\users\\raajas\\appdata\\local\\programs\\python\\python310\\lib\\site-packages (from spacy<4->fastai) (3.0.6)\n",
+      "Requirement already satisfied: catalogue<2.1.0,>=2.0.6 in c:\\users\\raajas\\appdata\\local\\programs\\python\\python310\\lib\\site-packages (from spacy<4->fastai) (2.0.7)\n",
+      "Requirement already satisfied: srsly<3.0.0,>=2.4.3 in c:\\users\\raajas\\appdata\\local\\programs\\python\\python310\\lib\\site-packages (from spacy<4->fastai) (2.4.3)\n",
+      "Requirement already satisfied: wasabi<1.1.0,>=0.9.1 in c:\\users\\raajas\\appdata\\local\\programs\\python\\python310\\lib\\site-packages (from spacy<4->fastai) (0.9.1)\n",
+      "Requirement already satisfied: pyparsing!=3.0.5,>=2.0.2 in c:\\users\\raajas\\appdata\\local\\programs\\python\\python310\\lib\\site-packages (from packaging->fastai) (3.0.9)\n",
+      "Requirement already satisfied: urllib3<1.27,>=1.21.1 in c:\\users\\raajas\\appdata\\local\\programs\\python\\python310\\lib\\site-packages (from requests->fastai) (1.26.9)\n",
+      "Requirement already satisfied: idna<4,>=2.5 in c:\\users\\raajas\\appdata\\local\\programs\\python\\python310\\lib\\site-packages (from requests->fastai) (3.3)\n",
+      "Requirement already satisfied: certifi>=2017.4.17 in c:\\users\\raajas\\appdata\\local\\programs\\python\\python310\\lib\\site-packages (from requests->fastai) (2022.5.18.1)\n",
+      "Requirement already satisfied: charset-normalizer~=2.0.0 in c:\\users\\raajas\\appdata\\local\\programs\\python\\python310\\lib\\site-packages (from requests->fastai) (2.0.12)\n",
+      "Requirement already satisfied: typing-extensions in c:\\users\\raajas\\appdata\\local\\programs\\python\\python310\\lib\\site-packages (from torch<1.12,>=1.7.0->fastai) (4.2.0)\n",
+      "Requirement already satisfied: fonttools>=4.22.0 in c:\\users\\raajas\\appdata\\local\\programs\\python\\python310\\lib\\site-packages (from matplotlib->fastai) (4.33.3)\n",
+      "Requirement already satisfied: cycler>=0.10 in c:\\users\\raajas\\appdata\\local\\programs\\python\\python310\\lib\\site-packages (from matplotlib->fastai) (0.11.0)\n",
+      "Requirement already satisfied: kiwisolver>=1.0.1 in c:\\users\\raajas\\appdata\\local\\programs\\python\\python310\\lib\\site-packages (from matplotlib->fastai) (1.4.2)\n",
+      "Requirement already satisfied: python-dateutil>=2.7 in c:\\users\\raajas\\appdata\\local\\programs\\python\\python310\\lib\\site-packages (from matplotlib->fastai) (2.8.2)\n",
+      "Requirement already satisfied: pytz>=2020.1 in c:\\users\\raajas\\appdata\\local\\programs\\python\\python310\\lib\\site-packages (from pandas->fastai) (2022.1)\n",
+      "Requirement already satisfied: joblib>=1.0.0 in c:\\users\\raajas\\appdata\\local\\programs\\python\\python310\\lib\\site-packages (from scikit-learn->fastai) (1.1.0)\n",
+      "Requirement already satisfied: threadpoolctl>=2.0.0 in c:\\users\\raajas\\appdata\\local\\programs\\python\\python310\\lib\\site-packages (from scikit-learn->fastai) (3.1.0)\n",
+      "Requirement already satisfied: smart-open<6.0.0,>=5.0.0 in c:\\users\\raajas\\appdata\\local\\programs\\python\\python310\\lib\\site-packages (from pathy>=0.3.5->spacy<4->fastai) (5.2.1)\n",
+      "Requirement already satisfied: six>=1.5 in c:\\users\\raajas\\appdata\\local\\programs\\python\\python310\\lib\\site-packages (from python-dateutil>=2.7->matplotlib->fastai) (1.16.0)\n",
+      "Requirement already satisfied: colorama in c:\\users\\raajas\\appdata\\local\\programs\\python\\python310\\lib\\site-packages (from tqdm<5.0.0,>=4.38.0->spacy<4->fastai) (0.4.4)\n",
+      "Requirement already satisfied: click<9.0.0,>=7.1.1 in c:\\users\\raajas\\appdata\\local\\programs\\python\\python310\\lib\\site-packages (from typer<0.5.0,>=0.3.0->spacy<4->fastai) (8.1.3)\n",
+      "Requirement already satisfied: MarkupSafe>=2.0 in c:\\users\\raajas\\appdata\\local\\programs\\python\\python310\\lib\\site-packages (from jinja2->spacy<4->fastai) (2.1.1)\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "WARNING: You are using pip version 22.0.4; however, version 22.1.2 is available.\n",
+      "You should consider upgrading via the 'C:\\Users\\Raajas\\AppData\\Local\\Programs\\Python\\Python310\\python.exe -m pip install --upgrade pip' command.\n",
+      "ERROR: Could not find a version that satisfies the requirement fastai.vision.widgets (from versions: none)\n",
+      "ERROR: No matching distribution found for fastai.vision.widgets\n",
+      "WARNING: You are using pip version 22.0.4; however, version 22.1.2 is available.\n",
+      "You should consider upgrading via the 'C:\\Users\\Raajas\\AppData\\Local\\Programs\\Python\\Python310\\python.exe -m pip install --upgrade pip' command.\n"
+     ]
+    }
+   ],
    "source": [
     "#hide\n",
     "! [ -e /content ] && pip install -Uqq fastbook\n",
     "import fastbook\n",
+    "!pip install fastai\n",
+    "!pip install fastai.vision.widgets\n",
     "fastbook.setup_book()"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 8,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -347,6 +428,57 @@
    ],
    "source": [
     "search_images_bing"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### If you face issues while using the Azure Bing Image Search Service, Simply use the api function for image search using duckduckgo search engine. \n",
+    "\n",
+    "This service is  free and usable simply by using the *search_images_ddg* function"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<function fastbook.search_images_ddg(term, max_images=200)>"
+      ]
+     },
+     "execution_count": 9,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "search_images_ddg"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "150"
+      ]
+     },
+     "execution_count": 12,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "#uncomment and test the duckduckgo image search api: \n",
+    "results = search_images_ddg('black bear',max_images=150)\n",
+    "len(results)"
    ]
   },
   {
@@ -2004,9 +2136,21 @@
    "split_at_heading": true
   },
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.4"
   }
  },
  "nbformat": 4,

--- a/02_production.ipynb
+++ b/02_production.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 13,
    "metadata": {},
    "outputs": [
     {
@@ -12,90 +12,18 @@
       "'[' is not recognized as an internal or external command,\n",
       "operable program or batch file.\n"
      ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Requirement already satisfied: fastai in c:\\users\\raajas\\appdata\\local\\programs\\python\\python310\\lib\\site-packages (2.6.3)\n",
-      "Requirement already satisfied: pip in c:\\users\\raajas\\appdata\\local\\programs\\python\\python310\\lib\\site-packages (from fastai) (22.0.4)\n",
-      "Requirement already satisfied: pandas in c:\\users\\raajas\\appdata\\local\\programs\\python\\python310\\lib\\site-packages (from fastai) (1.4.2)\n",
-      "Requirement already satisfied: fastdownload<2,>=0.0.5 in c:\\users\\raajas\\appdata\\local\\programs\\python\\python310\\lib\\site-packages (from fastai) (0.0.6)\n",
-      "Requirement already satisfied: fastcore<1.5,>=1.3.27 in c:\\users\\raajas\\appdata\\local\\programs\\python\\python310\\lib\\site-packages (from fastai) (1.4.3)\n",
-      "Requirement already satisfied: packaging in c:\\users\\raajas\\appdata\\local\\programs\\python\\python310\\lib\\site-packages (from fastai) (21.3)\n",
-      "Requirement already satisfied: scipy in c:\\users\\raajas\\appdata\\local\\programs\\python\\python310\\lib\\site-packages (from fastai) (1.8.1)\n",
-      "Requirement already satisfied: requests in c:\\users\\raajas\\appdata\\local\\programs\\python\\python310\\lib\\site-packages (from fastai) (2.27.1)\n",
-      "Requirement already satisfied: scikit-learn in c:\\users\\raajas\\appdata\\local\\programs\\python\\python310\\lib\\site-packages (from fastai) (1.1.1)\n",
-      "Requirement already satisfied: pillow>6.0.0 in c:\\users\\raajas\\appdata\\local\\programs\\python\\python310\\lib\\site-packages (from fastai) (9.1.1)\n",
-      "Requirement already satisfied: fastprogress>=0.2.4 in c:\\users\\raajas\\appdata\\local\\programs\\python\\python310\\lib\\site-packages (from fastai) (1.0.2)\n",
-      "Requirement already satisfied: torch<1.12,>=1.7.0 in c:\\users\\raajas\\appdata\\local\\programs\\python\\python310\\lib\\site-packages (from fastai) (1.11.0)\n",
-      "Requirement already satisfied: torchvision>=0.8.2 in c:\\users\\raajas\\appdata\\local\\programs\\python\\python310\\lib\\site-packages (from fastai) (0.12.0)\n",
-      "Requirement already satisfied: spacy<4 in c:\\users\\raajas\\appdata\\local\\programs\\python\\python310\\lib\\site-packages (from fastai) (3.3.0)\n",
-      "Requirement already satisfied: pyyaml in c:\\users\\raajas\\appdata\\local\\programs\\python\\python310\\lib\\site-packages (from fastai) (6.0)\n",
-      "Requirement already satisfied: matplotlib in c:\\users\\raajas\\appdata\\local\\programs\\python\\python310\\lib\\site-packages (from fastai) (3.5.2)\n",
-      "Requirement already satisfied: cymem<2.1.0,>=2.0.2 in c:\\users\\raajas\\appdata\\local\\programs\\python\\python310\\lib\\site-packages (from spacy<4->fastai) (2.0.6)\n",
-      "Requirement already satisfied: blis<0.8.0,>=0.4.0 in c:\\users\\raajas\\appdata\\local\\programs\\python\\python310\\lib\\site-packages (from spacy<4->fastai) (0.7.7)\n",
-      "Requirement already satisfied: jinja2 in c:\\users\\raajas\\appdata\\local\\programs\\python\\python310\\lib\\site-packages (from spacy<4->fastai) (3.1.2)\n",
-      "Requirement already satisfied: spacy-legacy<3.1.0,>=3.0.9 in c:\\users\\raajas\\appdata\\local\\programs\\python\\python310\\lib\\site-packages (from spacy<4->fastai) (3.0.9)\n",
-      "Requirement already satisfied: numpy>=1.15.0 in c:\\users\\raajas\\appdata\\local\\programs\\python\\python310\\lib\\site-packages (from spacy<4->fastai) (1.22.4)\n",
-      "Requirement already satisfied: setuptools in c:\\users\\raajas\\appdata\\local\\programs\\python\\python310\\lib\\site-packages (from spacy<4->fastai) (58.1.0)\n",
-      "Requirement already satisfied: pathy>=0.3.5 in c:\\users\\raajas\\appdata\\local\\programs\\python\\python310\\lib\\site-packages (from spacy<4->fastai) (0.6.1)\n",
-      "Requirement already satisfied: thinc<8.1.0,>=8.0.14 in c:\\users\\raajas\\appdata\\local\\programs\\python\\python310\\lib\\site-packages (from spacy<4->fastai) (8.0.17)\n",
-      "Requirement already satisfied: murmurhash<1.1.0,>=0.28.0 in c:\\users\\raajas\\appdata\\local\\programs\\python\\python310\\lib\\site-packages (from spacy<4->fastai) (1.0.7)\n",
-      "Requirement already satisfied: typer<0.5.0,>=0.3.0 in c:\\users\\raajas\\appdata\\local\\programs\\python\\python310\\lib\\site-packages (from spacy<4->fastai) (0.4.1)\n",
-      "Requirement already satisfied: langcodes<4.0.0,>=3.2.0 in c:\\users\\raajas\\appdata\\local\\programs\\python\\python310\\lib\\site-packages (from spacy<4->fastai) (3.3.0)\n",
-      "Requirement already satisfied: tqdm<5.0.0,>=4.38.0 in c:\\users\\raajas\\appdata\\local\\programs\\python\\python310\\lib\\site-packages (from spacy<4->fastai) (4.64.0)\n",
-      "Requirement already satisfied: pydantic!=1.8,!=1.8.1,<1.9.0,>=1.7.4 in c:\\users\\raajas\\appdata\\local\\programs\\python\\python310\\lib\\site-packages (from spacy<4->fastai) (1.8.2)\n",
-      "Requirement already satisfied: spacy-loggers<2.0.0,>=1.0.0 in c:\\users\\raajas\\appdata\\local\\programs\\python\\python310\\lib\\site-packages (from spacy<4->fastai) (1.0.2)\n",
-      "Requirement already satisfied: preshed<3.1.0,>=3.0.2 in c:\\users\\raajas\\appdata\\local\\programs\\python\\python310\\lib\\site-packages (from spacy<4->fastai) (3.0.6)\n",
-      "Requirement already satisfied: catalogue<2.1.0,>=2.0.6 in c:\\users\\raajas\\appdata\\local\\programs\\python\\python310\\lib\\site-packages (from spacy<4->fastai) (2.0.7)\n",
-      "Requirement already satisfied: srsly<3.0.0,>=2.4.3 in c:\\users\\raajas\\appdata\\local\\programs\\python\\python310\\lib\\site-packages (from spacy<4->fastai) (2.4.3)\n",
-      "Requirement already satisfied: wasabi<1.1.0,>=0.9.1 in c:\\users\\raajas\\appdata\\local\\programs\\python\\python310\\lib\\site-packages (from spacy<4->fastai) (0.9.1)\n",
-      "Requirement already satisfied: pyparsing!=3.0.5,>=2.0.2 in c:\\users\\raajas\\appdata\\local\\programs\\python\\python310\\lib\\site-packages (from packaging->fastai) (3.0.9)\n",
-      "Requirement already satisfied: urllib3<1.27,>=1.21.1 in c:\\users\\raajas\\appdata\\local\\programs\\python\\python310\\lib\\site-packages (from requests->fastai) (1.26.9)\n",
-      "Requirement already satisfied: idna<4,>=2.5 in c:\\users\\raajas\\appdata\\local\\programs\\python\\python310\\lib\\site-packages (from requests->fastai) (3.3)\n",
-      "Requirement already satisfied: certifi>=2017.4.17 in c:\\users\\raajas\\appdata\\local\\programs\\python\\python310\\lib\\site-packages (from requests->fastai) (2022.5.18.1)\n",
-      "Requirement already satisfied: charset-normalizer~=2.0.0 in c:\\users\\raajas\\appdata\\local\\programs\\python\\python310\\lib\\site-packages (from requests->fastai) (2.0.12)\n",
-      "Requirement already satisfied: typing-extensions in c:\\users\\raajas\\appdata\\local\\programs\\python\\python310\\lib\\site-packages (from torch<1.12,>=1.7.0->fastai) (4.2.0)\n",
-      "Requirement already satisfied: fonttools>=4.22.0 in c:\\users\\raajas\\appdata\\local\\programs\\python\\python310\\lib\\site-packages (from matplotlib->fastai) (4.33.3)\n",
-      "Requirement already satisfied: cycler>=0.10 in c:\\users\\raajas\\appdata\\local\\programs\\python\\python310\\lib\\site-packages (from matplotlib->fastai) (0.11.0)\n",
-      "Requirement already satisfied: kiwisolver>=1.0.1 in c:\\users\\raajas\\appdata\\local\\programs\\python\\python310\\lib\\site-packages (from matplotlib->fastai) (1.4.2)\n",
-      "Requirement already satisfied: python-dateutil>=2.7 in c:\\users\\raajas\\appdata\\local\\programs\\python\\python310\\lib\\site-packages (from matplotlib->fastai) (2.8.2)\n",
-      "Requirement already satisfied: pytz>=2020.1 in c:\\users\\raajas\\appdata\\local\\programs\\python\\python310\\lib\\site-packages (from pandas->fastai) (2022.1)\n",
-      "Requirement already satisfied: joblib>=1.0.0 in c:\\users\\raajas\\appdata\\local\\programs\\python\\python310\\lib\\site-packages (from scikit-learn->fastai) (1.1.0)\n",
-      "Requirement already satisfied: threadpoolctl>=2.0.0 in c:\\users\\raajas\\appdata\\local\\programs\\python\\python310\\lib\\site-packages (from scikit-learn->fastai) (3.1.0)\n",
-      "Requirement already satisfied: smart-open<6.0.0,>=5.0.0 in c:\\users\\raajas\\appdata\\local\\programs\\python\\python310\\lib\\site-packages (from pathy>=0.3.5->spacy<4->fastai) (5.2.1)\n",
-      "Requirement already satisfied: six>=1.5 in c:\\users\\raajas\\appdata\\local\\programs\\python\\python310\\lib\\site-packages (from python-dateutil>=2.7->matplotlib->fastai) (1.16.0)\n",
-      "Requirement already satisfied: colorama in c:\\users\\raajas\\appdata\\local\\programs\\python\\python310\\lib\\site-packages (from tqdm<5.0.0,>=4.38.0->spacy<4->fastai) (0.4.4)\n",
-      "Requirement already satisfied: click<9.0.0,>=7.1.1 in c:\\users\\raajas\\appdata\\local\\programs\\python\\python310\\lib\\site-packages (from typer<0.5.0,>=0.3.0->spacy<4->fastai) (8.1.3)\n",
-      "Requirement already satisfied: MarkupSafe>=2.0 in c:\\users\\raajas\\appdata\\local\\programs\\python\\python310\\lib\\site-packages (from jinja2->spacy<4->fastai) (2.1.1)\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "WARNING: You are using pip version 22.0.4; however, version 22.1.2 is available.\n",
-      "You should consider upgrading via the 'C:\\Users\\Raajas\\AppData\\Local\\Programs\\Python\\Python310\\python.exe -m pip install --upgrade pip' command.\n",
-      "ERROR: Could not find a version that satisfies the requirement fastai.vision.widgets (from versions: none)\n",
-      "ERROR: No matching distribution found for fastai.vision.widgets\n",
-      "WARNING: You are using pip version 22.0.4; however, version 22.1.2 is available.\n",
-      "You should consider upgrading via the 'C:\\Users\\Raajas\\AppData\\Local\\Programs\\Python\\Python310\\python.exe -m pip install --upgrade pip' command.\n"
-     ]
     }
    ],
    "source": [
     "#hide\n",
     "! [ -e /content ] && pip install -Uqq fastbook\n",
     "import fastbook\n",
-    "!pip install fastai\n",
-    "!pip install fastai.vision.widgets\n",
     "fastbook.setup_book()"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 14,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -412,7 +340,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 15,
    "metadata": {},
    "outputs": [
     {
@@ -421,7 +349,7 @@
        "<function fastbook.search_images_bing(key, term, min_sz=128, max_images=150)>"
       ]
      },
-     "execution_count": null,
+     "execution_count": 15,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -434,14 +362,14 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "#### If you face issues while using the Azure Bing Image Search Service, Simply use the api function for image search using duckduckgo search engine. \n",
+    "#### If you face issues while using the Azure Bing Image Search Service, Simply use the api function for image search which uses the  duckduckgo search engine. \n",
     "\n",
     "This service is  free and usable simply by using the *search_images_ddg* function"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 17,
    "metadata": {},
    "outputs": [
     {
@@ -450,7 +378,7 @@
        "<function fastbook.search_images_ddg(term, max_images=200)>"
       ]
      },
-     "execution_count": 9,
+     "execution_count": 17,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -461,7 +389,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 18,
    "metadata": {},
    "outputs": [
     {
@@ -470,13 +398,12 @@
        "150"
       ]
      },
-     "execution_count": 12,
+     "execution_count": 18,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "#uncomment and test the duckduckgo image search api: \n",
     "results = search_images_ddg('black bear',max_images=150)\n",
     "len(results)"
    ]


### PR DESCRIPTION
Since a lot of users face issues using the Azure Bing Image Search Service, I have looked into the fastbook references itself and added the reference for using the duckduckgo api function `search_images_ddg` for downloading images which is used similarly to the bing image search function (i.e. `search_images_bing` ) where neither an azure account or a key is required. 

Commit with sha **e9212b6a3c9814b9995048966d5f574af037aebc**  is the final commit, after editing out all spelling mistakes and extra imports during usage. 

