### PR TITLE
fixing paper author's name

### DIFF
--- a/01_intro.ipynb
+++ b/01_intro.ipynb
@@ -2377,7 +2377,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "This model is using the [*Adult* dataset](http://robotics.stanford.edu/~ronnyk/nbtree.pdf), from the paper \"Scaling Up the Accuracy of Naive-Bayes Classifiers: a Decision-Tree Hybrid\" by Rob Kohavi, which contains some demographic data about individuals (like their education, marital status, race, sex, and whether or not they have an annual income greater than \\$50k). The model is over 80\\% accurate, and took around 30 seconds to train."
+    "This model is using the [*Adult* dataset](http://robotics.stanford.edu/~ronnyk/nbtree.pdf), from the paper \"Scaling Up the Accuracy of Naive-Bayes Classifiers: a Decision-Tree Hybrid\" by Ron Kohavi, which contains some demographic data about individuals (like their education, marital status, race, sex, and whether or not they have an annual income greater than \\$50k). The model is over 80\\% accurate, and took around 30 seconds to train."
    ]
   },
   {


### PR DESCRIPTION
"Scaling Up the Accuracy of Naive-Bayes Classifiers: a Decision-Tree Hybrid" incorrectly cited to Rob Kohavi rather than the correct "Ron Kohavi"
Source: https://www.aaai.org/Papers/KDD/1996/KDD96-033.pdf
His site: http://robotics.stanford.edu/~ronnyk/