### PR TITLE
04_mnist_basics remove redundant .float() call

### DIFF
--- a/04_mnist_basics.ipynb
+++ b/04_mnist_basics.ipynb
@@ -1756,7 +1756,7 @@
     }
    ],
    "source": [
-    "F.l1_loss(a_3.float(),mean7), F.mse_loss(a_3,mean7).sqrt()"
+    "F.l1_loss(a_3,mean7), F.mse_loss(a_3,mean7).sqrt()"
    ]
   },
   {


### PR DESCRIPTION
The `.float()` call is not needed as `a_3` is already float