### PR TITLE
Fix broken datasets link

### DIFF
--- a/01_intro.ipynb
+++ b/01_intro.ipynb
@@ -1490,7 +1490,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The second line downloads a standard dataset from the [fast.ai datasets collection](https://course.fast.ai/datasets) (if not previously downloaded) to your server, extracts it (if not previously extracted), and returns a `Path` object with the extracted location:\n",
+    "The second line downloads a standard dataset from the [fast.ai datasets collection](https://docs.fast.ai/data.external.html) (if not previously downloaded) to your server, extracts it (if not previously extracted), and returns a `Path` object with the extracted location:\n",
     "\n",
     "```python\n",
     "path = untar_data(URLs.PETS)/'images'\n",


### PR DESCRIPTION
I'm not positive this is the proper destination for this broken link, but I couldn't find a valid alternative under course.fast.ai.