### PR TITLE
Nit in 02_production.ipynb, separates code concerns

### DIFF
--- a/clean/02_production.ipynb
+++ b/clean/02_production.ipynb
@@ -192,11 +192,11 @@
    "source": [
     "if not path.exists():\n",
     "    path.mkdir()\n",
-    "    for o in bear_types:\n",
-    "        dest = (path/o)\n",
-    "        dest.mkdir(exist_ok=True)\n",
-    "        results = search_images_bing(key, f'{o} bear')\n",
-    "        download_images(dest, urls=results.attrgot('contentUrl'))"
+    "for o in bear_types:\n",
+    "    dest = (path/o)\n",
+    "    dest.mkdir(exist_ok=True)\n",
+    "    results = search_images_bing(key, f'{o} bear')\n",
+    "    download_images(dest, urls=results.attrgot('contentUrl'))"
    ]
   },
   {


### PR DESCRIPTION
Separates concerns, for ex. downloads images if empty folder 'bears' already exists.