### PR TITLE
Fixed name of paper author and link to paper

### DIFF
--- a/01_intro.ipynb
+++ b/01_intro.ipynb
@@ -2377,7 +2377,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "This model is using the [*Adult* dataset](http://robotics.stanford.edu/~ronnyk/nbtree.pdf), from the paper \"Scaling Up the Accuracy of Naive-Bayes Classifiers: a Decision-Tree Hybrid\" by Rob Kohavi, which contains some demographic data about individuals (like their education, marital status, race, sex, and whether or not they have an annual income greater than \\$50k). The model is over 80\\% accurate, and took around 30 seconds to train."
+    "This model is using the *Adult* dataset, from the [paper]((http://robotics.stanford.edu/~ronnyk/nbtree.pdf) \"Scaling Up the Accuracy of Naive-Bayes Classifiers: a Decision-Tree Hybrid\" by Ron Kohavi, which contains some demographic data about individuals (like their education, marital status, race, sex, and whether or not they have an annual income greater than \\$50k). The model is over 80\\% accurate, and took around 30 seconds to train."
    ]
   },
   {
@@ -2917,6 +2917,18 @@
    "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.15"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Fixed author name (it's Ro*n* Kohavi) and associated the link with the paper, since the link goes to the paper, not the dataset.

In the diff, I'm not sure if there's a way to avoid the `language_info` part.
