### PR TITLE
bugfix to 15_arch_details.ipynb create_body call

### DIFF
--- a/15_arch_details.ipynb
+++ b/15_arch_details.ipynb
@@ -343,7 +343,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "encoder = create_body(resnet34, cut=-2)"
+    "encoder = create_body(resnet34(), cut=-2)"
    ]
   },
   {


### PR DESCRIPTION
I run this notebook in [Google colab](https://colab.research.google.com/github/fastai/fastbook/blob/master/15_arch_details.ipynb) and got an error when using simply the model name as the input to `create_body` function. Since `children` can be called from the function form, I added the parentheses in the notebook, so `encoder = create_body(resnet34, cut=-2)` became `encoder = create_body(resnet34(), cut=-2)` and the notebook runs fine.