### PR TITLE
Downgrading fastai version

### DIFF
--- a/01_intro.ipynb
+++ b/01_intro.ipynb
@@ -7,7 +7,7 @@
    "outputs": [],
    "source": [
     "#hide\n",
-    "! [ -e /content ] && pip install -Uqq fastbook\n",
+    "!pip install -Uqq fastbook\n",
     "import fastbook\n",
     "fastbook.setup_book()"
    ]

--- a/09_tabular.ipynb
+++ b/09_tabular.ipynb
@@ -7,7 +7,7 @@
    "outputs": [],
    "source": [
     "#hide\n",
-    "! [ -e /content ] && pip install -Uqq fastbook kaggle waterfallcharts treeinterpreter dtreeviz\n",
+    "!pip install -Uqq fastbook kaggle waterfallcharts treeinterpreter dtreeviz==1.3.7\n",
     "import fastbook\n",
     "fastbook.setup_book()"
    ]

--- a/15_arch_details.ipynb
+++ b/15_arch_details.ipynb
@@ -343,7 +343,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "encoder = create_body(resnet34, cut=-2)"
+    "encoder = create_body(resnet34(), cut=-2)"
    ]
   },
   {

--- a/15_arch_details.ipynb
+++ b/15_arch_details.ipynb
@@ -343,7 +343,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "encoder = create_body(resnet34(), cut=-2)"
+    "encoder = create_body(resnet34(pretrained=True), cut=-2)"
    ]
   },
   {

--- a/clean/01_intro.ipynb
+++ b/clean/01_intro.ipynb
@@ -7,7 +7,7 @@
    "outputs": [],
    "source": [
     "#hide\n",
-    "! [ -e /content ] && pip install -Uqq fastbook\n",
+    "!pip install -Uqq fastbook\n",
     "import fastbook\n",
     "fastbook.setup_book()"
    ]

--- a/clean/15_arch_details.ipynb
+++ b/clean/15_arch_details.ipynb
@@ -147,7 +147,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "encoder = create_body(resnet34, cut=-2)"
+    "encoder = create_body(resnet34(), cut=-2)"
    ]
   },
   {

--- a/clean/15_arch_details.ipynb
+++ b/clean/15_arch_details.ipynb
@@ -147,7 +147,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "encoder = create_body(resnet34(), cut=-2)"
+    "encoder = create_body(resnet34(pretrained=True), cut=-2)"
    ]
   },
   {

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-fastai>=2.0.0
+fastai==2.7.10
 graphviz
 ipywidgets
 matplotlib

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ ipywidgets
 matplotlib
 nbdev>=0.2.12
 pandas
-scikit_learn
+scikit_learn==1.1.3
 azure-cognitiveservices-search-imagesearch
 sentencepiece
 jupyter

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ pandas
 scikit_learn
 azure-cognitiveservices-search-imagesearch
 sentencepiece
+jupyter


### PR DESCRIPTION
I was having some troubles when I tried to set up my local environment to run the code.
Basically, I was creating a virtualenv and installing all the dependencies from requirements.txt, but when `learn.predict(img)` was called, it threw an error. The same happened when I tried to set up a conda environment.
The reasons weren't clear, but finally I found a thread explaining a similar problem (https://forums.fast.ai/t/lesson-1-official-topic/95287/469). So, in fact, it was installing the version 2.7.11 of fastai. I also added the jupyter dependency because the default version installed from the previous dependencies doesn't work properly either.