### PR TITLE
Add missing deps to `environment.yml` and `clean.py` 

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -7,6 +7,8 @@ dependencies:
   - python>=3.6
   - pytorch>=1.6
   - torchvision
+  - execnb
+  - nbformat
   - pip
   - pip:
     - -r requirements.txt

--- a/tools/clean.py
+++ b/tools/clean.py
@@ -4,6 +4,7 @@ import nbformat
 from nbdev.export import *
 from nbdev.clean import *
 from fastcore.all import *
+from execnb.nbio import *
 
 _re_header = re.compile(r'^#+\s+\S+')
 _re_clean  = re.compile(r'^\s*#\s*clean\s*')


### PR DESCRIPTION
* Add missing deps `execnb` and `nbformat` to `environment.yml`
* Missing include in `clean.py`

I was able to execute `clean.py` after these changes as follows:
```
$ conda env create -f environment.yml
...
$ conda activate fastbook
...
$ python tools/clean.py
...
<success>
```

Without these changes I get this error when executing `clean.py` (steps same as above):
```
Traceback (most recent call last):
  File "/Users/gunchu/Desktop/Code/fastbook/tools/clean.py", line 3, in <module>
    import nbformat
ModuleNotFoundError: No module named 'nbformat'
```