### PR TITLE
Regenerate `clean/` folder + Fix notebook validation errors caused by extra fields

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-    "python.formatting.provider": "black"
-}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "python.formatting.provider": "black"
+}

--- a/clean/01_intro.ipynb
+++ b/clean/01_intro.ipynb
@@ -3,7 +3,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 0,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -16,7 +15,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 1,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -26,7 +24,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 3,
    "metadata": {},
    "source": [
     "# Your Deep Learning Journey"
@@ -34,7 +31,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 5,
    "metadata": {},
    "source": [
     "## Deep Learning Is for Everyone"
@@ -42,7 +38,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 9,
    "metadata": {},
    "source": [
     "## Neural Networks: A Brief History"
@@ -50,7 +45,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 15,
    "metadata": {},
    "source": [
     "## Who We Are"
@@ -58,7 +52,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 22,
    "metadata": {},
    "source": [
     "## How to Learn Deep Learning"
@@ -66,7 +59,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 26,
    "metadata": {},
    "source": [
     "### Your Projects and Your Mindset"
@@ -74,7 +66,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 31,
    "metadata": {},
    "source": [
     "## The Software: PyTorch, fastai, and Jupyter"
@@ -82,7 +73,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 37,
    "metadata": {},
    "source": [
     "## Your First Model"
@@ -90,7 +80,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 40,
    "metadata": {},
    "source": [
     "### Getting a GPU Deep Learning Server"
@@ -98,7 +87,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 47,
    "metadata": {},
    "source": [
     "### Running Your First Notebook"
@@ -107,7 +95,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 54,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -126,7 +113,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 57,
    "metadata": {},
    "source": [
     "### Sidebar: This Book Was Written in Jupyter Notebooks"
@@ -135,7 +121,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 60,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -145,7 +130,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 62,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -155,7 +139,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 63,
    "metadata": {},
    "source": [
     "### End sidebar"
@@ -164,7 +147,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 65,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -175,7 +157,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 68,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -187,7 +168,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 69,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -199,7 +179,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 71,
    "metadata": {},
    "source": [
     "### What Is Machine Learning?"
@@ -208,7 +187,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 73,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -219,7 +197,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 79,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -230,7 +207,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 81,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -243,7 +219,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 83,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -253,7 +228,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 86,
    "metadata": {},
    "source": [
     "### What Is a Neural Network?"
@@ -261,7 +235,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 90,
    "metadata": {},
    "source": [
     "### A Bit of Deep Learning Jargon"
@@ -270,7 +243,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 92,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -282,7 +254,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 93,
    "metadata": {},
    "source": [
     "### Limitations Inherent To Machine Learning\n",
@@ -301,7 +272,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 96,
    "metadata": {},
    "source": [
     "### How Our Image Recognizer Works"
@@ -309,7 +279,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 115,
    "metadata": {},
    "source": [
     "### What Our Image Recognizer Learned"
@@ -317,7 +286,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 125,
    "metadata": {},
    "source": [
     "### Image Recognizers Can Tackle Non-Image Tasks"
@@ -325,7 +293,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 137,
    "metadata": {},
    "source": [
     "### Jargon Recap"
@@ -333,7 +300,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 140,
    "metadata": {},
    "source": [
     "## Deep Learning Is Not Just for Image Classification"
@@ -342,7 +308,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 142,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -360,7 +325,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 144,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -370,7 +334,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 146,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -383,7 +346,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 147,
    "metadata": {},
    "source": [
     "If you hit a \"CUDA out of memory error\" after running this cell, click on the menu Kernel, then restart. Instead of executing the cell above, copy and paste the following code in it:\n",
@@ -402,7 +364,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 149,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -411,7 +372,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 151,
    "metadata": {},
    "source": [
     "### Sidebar: The Order Matters"
@@ -419,7 +379,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 153,
    "metadata": {},
    "source": [
     "### End sidebar"
@@ -428,7 +387,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 158,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -447,7 +405,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 160,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -457,7 +414,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 163,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -471,7 +427,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 165,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -480,7 +435,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 166,
    "metadata": {},
    "source": [
     "### Sidebar: Datasets: Food for Models"
@@ -488,7 +442,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 168,
    "metadata": {},
    "source": [
     "### End sidebar"
@@ -496,7 +449,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 170,
    "metadata": {},
    "source": [
     "## Validation Sets and Test Sets"
@@ -504,7 +456,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 173,
    "metadata": {},
    "source": [
     "### Use Judgment in Defining Test Sets"
@@ -512,7 +463,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 185,
    "metadata": {},
    "source": [
     "## A _Choose Your Own Adventure_ moment"
@@ -520,7 +470,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 187,
    "metadata": {},
    "source": [
     "## Questionnaire"
@@ -528,7 +477,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 188,
    "metadata": {},
    "source": [
     "It can be hard to know in pages and pages of prose what the key things are that you really need to focus on and remember. So, we've prepared a list of questions and suggested steps to complete at the end of each chapter. All the answers are in the text of the chapter, so if you're not sure about anything here, reread that part of the text and make sure you understand it. Answers to all these questions are also available on the [book's website](https://book.fast.ai). You can also visit [the forums](https://forums.fast.ai) if you get stuck to get help from other folks studying this material.\n",
@@ -538,7 +486,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 189,
    "metadata": {},
    "source": [
     "1. Do you need these for deep learning?\n",
@@ -584,7 +531,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 190,
    "metadata": {},
    "source": [
     "### Further Research"
@@ -592,7 +538,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 191,
    "metadata": {},
    "source": [
     "Each chapter also has a \"Further Research\" section that poses questions that aren't fully answered in the text, or gives more advanced assignments. Answers to these questions aren't on the book's website; you'll need to do your own research!"
@@ -600,7 +545,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 192,
    "metadata": {},
    "source": [
     "1. Why is a GPU useful for deep learning? How is a CPU different, and why is it less effective for deep learning?\n",
@@ -610,7 +554,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 193,
    "metadata": {},
    "outputs": [],
    "source": []
@@ -627,6 +570,5 @@
   }
  },
  "nbformat": 4,
- "nbformat_minor": 4,
- "path_": "01_intro.ipynb"
+ "nbformat_minor": 4
 }

--- a/clean/01_intro.ipynb
+++ b/clean/01_intro.ipynb
@@ -3,6 +3,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 0,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -15,6 +16,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 1,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -24,6 +26,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 3,
    "metadata": {},
    "source": [
     "# Your Deep Learning Journey"
@@ -31,6 +34,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 5,
    "metadata": {},
    "source": [
     "## Deep Learning Is for Everyone"
@@ -38,6 +42,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 9,
    "metadata": {},
    "source": [
     "## Neural Networks: A Brief History"
@@ -45,6 +50,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 15,
    "metadata": {},
    "source": [
     "## Who We Are"
@@ -52,6 +58,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 22,
    "metadata": {},
    "source": [
     "## How to Learn Deep Learning"
@@ -59,6 +66,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 26,
    "metadata": {},
    "source": [
     "### Your Projects and Your Mindset"
@@ -66,6 +74,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 31,
    "metadata": {},
    "source": [
     "## The Software: PyTorch, fastai, and Jupyter"
@@ -73,6 +82,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 37,
    "metadata": {},
    "source": [
     "## Your First Model"
@@ -80,6 +90,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 40,
    "metadata": {},
    "source": [
     "### Getting a GPU Deep Learning Server"
@@ -87,6 +98,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 47,
    "metadata": {},
    "source": [
     "### Running Your First Notebook"
@@ -95,6 +107,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 54,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -113,6 +126,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 57,
    "metadata": {},
    "source": [
     "### Sidebar: This Book Was Written in Jupyter Notebooks"
@@ -121,6 +135,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 60,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -130,6 +145,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 62,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -139,6 +155,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 63,
    "metadata": {},
    "source": [
     "### End sidebar"
@@ -147,6 +164,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 65,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -157,6 +175,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 68,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -168,6 +187,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 69,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -179,6 +199,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 71,
    "metadata": {},
    "source": [
     "### What Is Machine Learning?"
@@ -187,6 +208,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 73,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -197,6 +219,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 79,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -207,6 +230,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 81,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -219,6 +243,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 83,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -228,6 +253,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 86,
    "metadata": {},
    "source": [
     "### What Is a Neural Network?"
@@ -235,6 +261,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 90,
    "metadata": {},
    "source": [
     "### A Bit of Deep Learning Jargon"
@@ -243,6 +270,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 92,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -254,6 +282,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 93,
    "metadata": {},
    "source": [
     "### Limitations Inherent To Machine Learning\n",
@@ -272,6 +301,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 96,
    "metadata": {},
    "source": [
     "### How Our Image Recognizer Works"
@@ -279,6 +309,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 115,
    "metadata": {},
    "source": [
     "### What Our Image Recognizer Learned"
@@ -286,6 +317,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 125,
    "metadata": {},
    "source": [
     "### Image Recognizers Can Tackle Non-Image Tasks"
@@ -293,6 +325,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 137,
    "metadata": {},
    "source": [
     "### Jargon Recap"
@@ -300,6 +333,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 140,
    "metadata": {},
    "source": [
     "## Deep Learning Is Not Just for Image Classification"
@@ -308,6 +342,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 142,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -325,6 +360,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 144,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -334,6 +370,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 146,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -346,6 +383,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 147,
    "metadata": {},
    "source": [
     "If you hit a \"CUDA out of memory error\" after running this cell, click on the menu Kernel, then restart. Instead of executing the cell above, copy and paste the following code in it:\n",
@@ -364,6 +402,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 149,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -372,6 +411,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 151,
    "metadata": {},
    "source": [
     "### Sidebar: The Order Matters"
@@ -379,6 +419,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 153,
    "metadata": {},
    "source": [
     "### End sidebar"
@@ -387,6 +428,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 158,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -405,6 +447,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 160,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -414,6 +457,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 163,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -427,6 +471,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 165,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -435,6 +480,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 166,
    "metadata": {},
    "source": [
     "### Sidebar: Datasets: Food for Models"
@@ -442,6 +488,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 168,
    "metadata": {},
    "source": [
     "### End sidebar"
@@ -449,6 +496,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 170,
    "metadata": {},
    "source": [
     "## Validation Sets and Test Sets"
@@ -456,6 +504,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 173,
    "metadata": {},
    "source": [
     "### Use Judgment in Defining Test Sets"
@@ -463,6 +512,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 185,
    "metadata": {},
    "source": [
     "## A _Choose Your Own Adventure_ moment"
@@ -470,6 +520,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 187,
    "metadata": {},
    "source": [
     "## Questionnaire"
@@ -477,6 +528,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 188,
    "metadata": {},
    "source": [
     "It can be hard to know in pages and pages of prose what the key things are that you really need to focus on and remember. So, we've prepared a list of questions and suggested steps to complete at the end of each chapter. All the answers are in the text of the chapter, so if you're not sure about anything here, reread that part of the text and make sure you understand it. Answers to all these questions are also available on the [book's website](https://book.fast.ai). You can also visit [the forums](https://forums.fast.ai) if you get stuck to get help from other folks studying this material.\n",
@@ -486,6 +538,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 189,
    "metadata": {},
    "source": [
     "1. Do you need these for deep learning?\n",
@@ -531,6 +584,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 190,
    "metadata": {},
    "source": [
     "### Further Research"
@@ -538,6 +592,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 191,
    "metadata": {},
    "source": [
     "Each chapter also has a \"Further Research\" section that poses questions that aren't fully answered in the text, or gives more advanced assignments. Answers to these questions aren't on the book's website; you'll need to do your own research!"
@@ -545,6 +600,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 192,
    "metadata": {},
    "source": [
     "1. Why is a GPU useful for deep learning? How is a CPU different, and why is it less effective for deep learning?\n",
@@ -554,6 +610,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 193,
    "metadata": {},
    "outputs": [],
    "source": []
@@ -564,11 +621,12 @@
    "split_at_heading": true
   },
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "python3",
    "language": "python",
    "name": "python3"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 4
+ "nbformat_minor": 4,
+ "path_": "01_intro.ipynb"
 }

--- a/clean/02_production.ipynb
+++ b/clean/02_production.ipynb
@@ -3,7 +3,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 0,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -16,7 +15,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 1,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -27,7 +25,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 3,
    "metadata": {},
    "source": [
     "# From Model to Production"
@@ -35,7 +32,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 5,
    "metadata": {},
    "source": [
     "## The Practice of Deep Learning"
@@ -43,7 +39,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 7,
    "metadata": {},
    "source": [
     "### Starting Your Project"
@@ -51,7 +46,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 11,
    "metadata": {},
    "source": [
     "### The State of Deep Learning"
@@ -59,7 +53,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 13,
    "metadata": {},
    "source": [
     "#### Computer vision"
@@ -67,7 +60,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 15,
    "metadata": {},
    "source": [
     "#### Text (natural language processing)"
@@ -75,7 +67,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 17,
    "metadata": {},
    "source": [
     "#### Combining text and images"
@@ -83,7 +74,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 19,
    "metadata": {},
    "source": [
     "#### Tabular data"
@@ -91,7 +81,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 21,
    "metadata": {},
    "source": [
     "#### Recommendation systems"
@@ -99,7 +88,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 24,
    "metadata": {},
    "source": [
     "#### Other data types"
@@ -107,7 +95,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 26,
    "metadata": {},
    "source": [
     "### The Drivetrain Approach"
@@ -115,7 +102,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 32,
    "metadata": {},
    "source": [
     "## Gathering Data"
@@ -123,7 +109,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 36,
    "metadata": {},
    "source": [
     "# clean\n",
@@ -133,7 +118,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 37,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -143,7 +127,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 39,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -153,7 +136,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 40,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -165,7 +147,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 42,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -176,7 +157,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 43,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -187,7 +167,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 44,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -198,7 +177,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 46,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -209,7 +187,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 47,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -225,7 +202,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 49,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -236,7 +212,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 52,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -247,7 +222,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 54,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -256,7 +230,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 55,
    "metadata": {},
    "source": [
     "### Sidebar: Getting Help in Jupyter Notebooks"
@@ -264,7 +237,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 57,
    "metadata": {},
    "source": [
     "### End sidebar"
@@ -272,7 +244,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 62,
    "metadata": {},
    "source": [
     "## From Data to DataLoaders"
@@ -281,7 +252,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 66,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -296,7 +266,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 69,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -306,7 +275,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 71,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -316,7 +284,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 73,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -328,7 +295,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 74,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -340,7 +306,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 76,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -351,7 +316,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 78,
    "metadata": {},
    "source": [
     "### Data Augmentation"
@@ -360,7 +324,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 80,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -371,7 +334,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 82,
    "metadata": {},
    "source": [
     "## Training Your Model, and Using It to Clean Your Data"
@@ -380,7 +342,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 84,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -393,7 +354,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 86,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -404,7 +364,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 88,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -415,7 +374,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 90,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -425,7 +383,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 92,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -436,7 +393,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 94,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -447,7 +403,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 98,
    "metadata": {},
    "source": [
     "## Turning Your Model into an Online Application"
@@ -455,7 +410,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 100,
    "metadata": {},
    "source": [
     "### Using the Model for Inference"
@@ -464,7 +418,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 102,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -474,7 +427,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 104,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -485,7 +437,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 106,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -495,7 +446,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 108,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -505,7 +455,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 110,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -514,7 +463,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 113,
    "metadata": {},
    "source": [
     "### Creating a Notebook App from the Model"
@@ -523,7 +471,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 115,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -534,7 +481,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 117,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -546,7 +492,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 118,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -556,7 +501,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 121,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -569,7 +513,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 123,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -579,7 +522,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 125,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -591,7 +533,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 127,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -602,7 +543,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 129,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -619,7 +559,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 131,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -631,7 +570,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 132,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -641,7 +579,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 135,
    "metadata": {},
    "source": [
     "### Turning Your Notebook into a Real App"
@@ -650,7 +587,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 136,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -661,7 +597,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 138,
    "metadata": {},
    "source": [
     "### Deploying your app"
@@ -669,7 +604,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 145,
    "metadata": {},
    "source": [
     "## How to Avoid Disaster"
@@ -677,7 +611,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 151,
    "metadata": {},
    "source": [
     "### Unforeseen Consequences and Feedback Loops"
@@ -685,7 +618,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 153,
    "metadata": {},
    "source": [
     "## Get Writing!"
@@ -693,7 +625,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 155,
    "metadata": {},
    "source": [
     "## Questionnaire"
@@ -701,7 +632,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 156,
    "metadata": {},
    "source": [
     "1. Provide an example of where the bear classification model might work poorly in production, due to structural or style differences in the training data.\n",
@@ -735,7 +665,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 157,
    "metadata": {},
    "source": [
     "### Further Research"
@@ -743,7 +672,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 158,
    "metadata": {},
    "source": [
     "1. Consider how the Drivetrain Approach maps to a project or problem you're interested in.\n",
@@ -755,7 +683,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 159,
    "metadata": {},
    "outputs": [],
    "source": []
@@ -772,6 +699,5 @@
   }
  },
  "nbformat": 4,
- "nbformat_minor": 4,
- "path_": "02_production.ipynb"
+ "nbformat_minor": 4
 }

--- a/clean/02_production.ipynb
+++ b/clean/02_production.ipynb
@@ -3,6 +3,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 0,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -15,6 +16,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 1,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -25,6 +27,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 3,
    "metadata": {},
    "source": [
     "# From Model to Production"
@@ -32,6 +35,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 5,
    "metadata": {},
    "source": [
     "## The Practice of Deep Learning"
@@ -39,6 +43,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 7,
    "metadata": {},
    "source": [
     "### Starting Your Project"
@@ -46,6 +51,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 11,
    "metadata": {},
    "source": [
     "### The State of Deep Learning"
@@ -53,6 +59,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 13,
    "metadata": {},
    "source": [
     "#### Computer vision"
@@ -60,6 +67,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 15,
    "metadata": {},
    "source": [
     "#### Text (natural language processing)"
@@ -67,6 +75,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 17,
    "metadata": {},
    "source": [
     "#### Combining text and images"
@@ -74,6 +83,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 19,
    "metadata": {},
    "source": [
     "#### Tabular data"
@@ -81,6 +91,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 21,
    "metadata": {},
    "source": [
     "#### Recommendation systems"
@@ -88,6 +99,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 24,
    "metadata": {},
    "source": [
     "#### Other data types"
@@ -95,6 +107,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 26,
    "metadata": {},
    "source": [
     "### The Drivetrain Approach"
@@ -102,6 +115,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 32,
    "metadata": {},
    "source": [
     "## Gathering Data"
@@ -109,6 +123,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 36,
    "metadata": {},
    "source": [
     "# clean\n",
@@ -118,6 +133,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 37,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -127,6 +143,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 39,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -136,6 +153,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 40,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -147,6 +165,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 42,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -157,6 +176,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 43,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -167,6 +187,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 44,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -177,6 +198,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 46,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -187,6 +209,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 47,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -202,6 +225,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 49,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -212,6 +236,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 52,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -222,6 +247,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 54,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -230,6 +256,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 55,
    "metadata": {},
    "source": [
     "### Sidebar: Getting Help in Jupyter Notebooks"
@@ -237,6 +264,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 57,
    "metadata": {},
    "source": [
     "### End sidebar"
@@ -244,6 +272,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 62,
    "metadata": {},
    "source": [
     "## From Data to DataLoaders"
@@ -252,6 +281,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 66,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -266,6 +296,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 69,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -275,6 +306,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 71,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -284,6 +316,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 73,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -295,6 +328,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 74,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -306,6 +340,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 76,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -316,6 +351,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 78,
    "metadata": {},
    "source": [
     "### Data Augmentation"
@@ -324,6 +360,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 80,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -334,6 +371,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 82,
    "metadata": {},
    "source": [
     "## Training Your Model, and Using It to Clean Your Data"
@@ -342,6 +380,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 84,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -354,6 +393,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 86,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -364,6 +404,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 88,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -374,6 +415,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 90,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -383,6 +425,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 92,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -393,6 +436,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 94,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -403,6 +447,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 98,
    "metadata": {},
    "source": [
     "## Turning Your Model into an Online Application"
@@ -410,6 +455,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 100,
    "metadata": {},
    "source": [
     "### Using the Model for Inference"
@@ -418,6 +464,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 102,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -427,6 +474,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 104,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -437,6 +485,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 106,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -446,6 +495,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 108,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -455,6 +505,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 110,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -463,6 +514,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 113,
    "metadata": {},
    "source": [
     "### Creating a Notebook App from the Model"
@@ -471,6 +523,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 115,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -481,6 +534,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 117,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -492,6 +546,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 118,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -501,6 +556,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 121,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -513,6 +569,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 123,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -522,6 +579,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 125,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -533,6 +591,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 127,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -543,6 +602,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 129,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -559,6 +619,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 131,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -570,6 +631,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 132,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -579,6 +641,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 135,
    "metadata": {},
    "source": [
     "### Turning Your Notebook into a Real App"
@@ -587,6 +650,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 136,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -597,6 +661,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 138,
    "metadata": {},
    "source": [
     "### Deploying your app"
@@ -604,6 +669,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 145,
    "metadata": {},
    "source": [
     "## How to Avoid Disaster"
@@ -611,6 +677,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 151,
    "metadata": {},
    "source": [
     "### Unforeseen Consequences and Feedback Loops"
@@ -618,6 +685,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 153,
    "metadata": {},
    "source": [
     "## Get Writing!"
@@ -625,6 +693,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 155,
    "metadata": {},
    "source": [
     "## Questionnaire"
@@ -632,6 +701,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 156,
    "metadata": {},
    "source": [
     "1. Provide an example of where the bear classification model might work poorly in production, due to structural or style differences in the training data.\n",
@@ -665,6 +735,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 157,
    "metadata": {},
    "source": [
     "### Further Research"
@@ -672,6 +743,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 158,
    "metadata": {},
    "source": [
     "1. Consider how the Drivetrain Approach maps to a project or problem you're interested in.\n",
@@ -683,6 +755,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 159,
    "metadata": {},
    "outputs": [],
    "source": []
@@ -693,11 +766,12 @@
    "split_at_heading": true
   },
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "python3",
    "language": "python",
    "name": "python3"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 4
+ "nbformat_minor": 4,
+ "path_": "02_production.ipynb"
 }

--- a/clean/03_ethics.ipynb
+++ b/clean/03_ethics.ipynb
@@ -3,6 +3,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 0,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -14,6 +15,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 2,
    "metadata": {},
    "source": [
     "# Data Ethics"
@@ -21,6 +23,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 3,
    "metadata": {},
    "source": [
     "### Sidebar: Acknowledgement: Dr. Rachel Thomas"
@@ -28,6 +31,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 5,
    "metadata": {},
    "source": [
     "### End sidebar"
@@ -35,6 +39,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 9,
    "metadata": {},
    "source": [
     "## Key Examples for Data Ethics"
@@ -42,6 +47,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 11,
    "metadata": {},
    "source": [
     "### Bugs and Recourse: Buggy Algorithm Used for Healthcare Benefits"
@@ -49,6 +55,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 13,
    "metadata": {},
    "source": [
     "### Feedback Loops: YouTube's Recommendation System"
@@ -56,6 +63,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 15,
    "metadata": {},
    "source": [
     "### Bias: Professor Latanya Sweeney \"Arrested\""
@@ -63,6 +71,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 19,
    "metadata": {},
    "source": [
     "### Why Does This Matter?"
@@ -70,6 +79,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 25,
    "metadata": {},
    "source": [
     "## Integrating Machine Learning with Product Design"
@@ -77,6 +87,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 29,
    "metadata": {},
    "source": [
     "## Topics in Data Ethics"
@@ -84,6 +95,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 32,
    "metadata": {},
    "source": [
     "### Recourse and Accountability"
@@ -91,6 +103,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 34,
    "metadata": {},
    "source": [
     "### Feedback Loops"
@@ -98,6 +111,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 42,
    "metadata": {},
    "source": [
     "### Bias"
@@ -105,6 +119,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 46,
    "metadata": {},
    "source": [
     "#### Historical bias"
@@ -112,6 +127,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 62,
    "metadata": {},
    "source": [
     "#### Measurement bias"
@@ -119,6 +135,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 64,
    "metadata": {},
    "source": [
     "#### Aggregation bias"
@@ -126,6 +143,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 66,
    "metadata": {},
    "source": [
     "#### Representation bias"
@@ -133,6 +151,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 70,
    "metadata": {},
    "source": [
     "### Addressing different types of bias"
@@ -140,6 +159,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 73,
    "metadata": {},
    "source": [
     "### Disinformation"
@@ -147,6 +167,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 77,
    "metadata": {},
    "source": [
     "## Identifying and Addressing Ethical Issues"
@@ -154,6 +175,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 79,
    "metadata": {},
    "source": [
     "### Analyze a Project You Are Working On"
@@ -161,6 +183,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 81,
    "metadata": {},
    "source": [
     "### Processes to Implement"
@@ -168,6 +191,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 83,
    "metadata": {},
    "source": [
     "#### Ethical lenses"
@@ -175,6 +199,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 85,
    "metadata": {},
    "source": [
     "### The Power of Diversity"
@@ -182,6 +207,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 88,
    "metadata": {},
    "source": [
     "### Fairness, Accountability, and Transparency"
@@ -189,6 +215,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 92,
    "metadata": {},
    "source": [
     "## Role of Policy"
@@ -196,6 +223,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 94,
    "metadata": {},
    "source": [
     "### The Effectiveness of Regulation"
@@ -203,6 +231,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 96,
    "metadata": {},
    "source": [
     "### Rights and Policy"
@@ -210,6 +239,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 98,
    "metadata": {},
    "source": [
     "### Cars: A Historical Precedent"
@@ -217,6 +247,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 100,
    "metadata": {},
    "source": [
     "## Conclusion"
@@ -224,6 +255,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 102,
    "metadata": {},
    "source": [
     "## Questionnaire"
@@ -231,6 +263,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 103,
    "metadata": {},
    "source": [
     "1. Does ethics provide a list of \"right answers\"?\n",
@@ -255,6 +288,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 104,
    "metadata": {},
    "source": [
     "### Further Research:"
@@ -262,6 +296,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 105,
    "metadata": {},
    "source": [
     "1. Read the article \"What Happens When an Algorithm Cuts Your Healthcare\". How could problems like this be avoided in the future?\n",
@@ -276,6 +311,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 106,
    "metadata": {},
    "source": [
     "## Deep Learning in Practice: That's a Wrap!"
@@ -283,6 +319,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 107,
    "metadata": {},
    "source": [
     "Congratulations! You've made it to the end of the first section of the book. In this section we've tried to show you what deep learning can do, and how you can use it to create real applications and products. At this point, you will get a lot more out of the book if you spend some time trying out what you've learned. Perhaps you have already been doing this as you go along—in which case, great! If not, that's no problem either... Now is a great time to start experimenting yourself.\n",
@@ -303,6 +340,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 108,
    "metadata": {},
    "outputs": [],
    "source": []
@@ -313,11 +351,12 @@
    "split_at_heading": true
   },
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "python3",
    "language": "python",
    "name": "python3"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 4
+ "nbformat_minor": 4,
+ "path_": "03_ethics.ipynb"
 }

--- a/clean/03_ethics.ipynb
+++ b/clean/03_ethics.ipynb
@@ -3,7 +3,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 0,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -15,7 +14,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 2,
    "metadata": {},
    "source": [
     "# Data Ethics"
@@ -23,7 +21,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 3,
    "metadata": {},
    "source": [
     "### Sidebar: Acknowledgement: Dr. Rachel Thomas"
@@ -31,7 +28,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 5,
    "metadata": {},
    "source": [
     "### End sidebar"
@@ -39,7 +35,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 9,
    "metadata": {},
    "source": [
     "## Key Examples for Data Ethics"
@@ -47,7 +42,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 11,
    "metadata": {},
    "source": [
     "### Bugs and Recourse: Buggy Algorithm Used for Healthcare Benefits"
@@ -55,7 +49,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 13,
    "metadata": {},
    "source": [
     "### Feedback Loops: YouTube's Recommendation System"
@@ -63,7 +56,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 15,
    "metadata": {},
    "source": [
     "### Bias: Professor Latanya Sweeney \"Arrested\""
@@ -71,7 +63,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 19,
    "metadata": {},
    "source": [
     "### Why Does This Matter?"
@@ -79,7 +70,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 25,
    "metadata": {},
    "source": [
     "## Integrating Machine Learning with Product Design"
@@ -87,7 +77,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 29,
    "metadata": {},
    "source": [
     "## Topics in Data Ethics"
@@ -95,7 +84,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 32,
    "metadata": {},
    "source": [
     "### Recourse and Accountability"
@@ -103,7 +91,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 34,
    "metadata": {},
    "source": [
     "### Feedback Loops"
@@ -111,7 +98,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 42,
    "metadata": {},
    "source": [
     "### Bias"
@@ -119,7 +105,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 46,
    "metadata": {},
    "source": [
     "#### Historical bias"
@@ -127,7 +112,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 62,
    "metadata": {},
    "source": [
     "#### Measurement bias"
@@ -135,7 +119,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 64,
    "metadata": {},
    "source": [
     "#### Aggregation bias"
@@ -143,7 +126,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 66,
    "metadata": {},
    "source": [
     "#### Representation bias"
@@ -151,7 +133,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 70,
    "metadata": {},
    "source": [
     "### Addressing different types of bias"
@@ -159,7 +140,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 73,
    "metadata": {},
    "source": [
     "### Disinformation"
@@ -167,7 +147,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 77,
    "metadata": {},
    "source": [
     "## Identifying and Addressing Ethical Issues"
@@ -175,7 +154,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 79,
    "metadata": {},
    "source": [
     "### Analyze a Project You Are Working On"
@@ -183,7 +161,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 81,
    "metadata": {},
    "source": [
     "### Processes to Implement"
@@ -191,7 +168,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 83,
    "metadata": {},
    "source": [
     "#### Ethical lenses"
@@ -199,7 +175,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 85,
    "metadata": {},
    "source": [
     "### The Power of Diversity"
@@ -207,7 +182,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 88,
    "metadata": {},
    "source": [
     "### Fairness, Accountability, and Transparency"
@@ -215,7 +189,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 92,
    "metadata": {},
    "source": [
     "## Role of Policy"
@@ -223,7 +196,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 94,
    "metadata": {},
    "source": [
     "### The Effectiveness of Regulation"
@@ -231,7 +203,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 96,
    "metadata": {},
    "source": [
     "### Rights and Policy"
@@ -239,7 +210,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 98,
    "metadata": {},
    "source": [
     "### Cars: A Historical Precedent"
@@ -247,7 +217,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 100,
    "metadata": {},
    "source": [
     "## Conclusion"
@@ -255,7 +224,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 102,
    "metadata": {},
    "source": [
     "## Questionnaire"
@@ -263,7 +231,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 103,
    "metadata": {},
    "source": [
     "1. Does ethics provide a list of \"right answers\"?\n",
@@ -288,7 +255,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 104,
    "metadata": {},
    "source": [
     "### Further Research:"
@@ -296,7 +262,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 105,
    "metadata": {},
    "source": [
     "1. Read the article \"What Happens When an Algorithm Cuts Your Healthcare\". How could problems like this be avoided in the future?\n",
@@ -311,7 +276,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 106,
    "metadata": {},
    "source": [
     "## Deep Learning in Practice: That's a Wrap!"
@@ -319,7 +283,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 107,
    "metadata": {},
    "source": [
     "Congratulations! You've made it to the end of the first section of the book. In this section we've tried to show you what deep learning can do, and how you can use it to create real applications and products. At this point, you will get a lot more out of the book if you spend some time trying out what you've learned. Perhaps you have already been doing this as you go along—in which case, great! If not, that's no problem either... Now is a great time to start experimenting yourself.\n",
@@ -340,7 +303,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 108,
    "metadata": {},
    "outputs": [],
    "source": []
@@ -357,6 +319,5 @@
   }
  },
  "nbformat": 4,
- "nbformat_minor": 4,
- "path_": "03_ethics.ipynb"
+ "nbformat_minor": 4
 }

--- a/clean/04_mnist_basics.ipynb
+++ b/clean/04_mnist_basics.ipynb
@@ -3,6 +3,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 0,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -15,6 +16,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 1,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -27,6 +29,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 3,
    "metadata": {},
    "source": [
     "# Under the Hood: Training a Digit Classifier"
@@ -34,6 +37,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 5,
    "metadata": {},
    "source": [
     "## Pixels: The Foundations of Computer Vision"
@@ -41,6 +45,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 7,
    "metadata": {},
    "source": [
     "## Sidebar: Tenacity and Deep Learning"
@@ -48,6 +53,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 9,
    "metadata": {},
    "source": [
     "## End sidebar"
@@ -56,6 +62,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 11,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -65,6 +72,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 12,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -75,6 +83,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 14,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -84,6 +93,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 16,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -93,6 +103,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 18,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -104,6 +115,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 20,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -115,6 +127,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 22,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -124,6 +137,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 24,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -133,6 +147,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 26,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -143,6 +158,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 29,
    "metadata": {},
    "source": [
     "## First Try: Pixel Similarity"
@@ -151,6 +167,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 33,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -162,6 +179,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 36,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -171,6 +189,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 38,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -182,6 +201,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 40,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -191,6 +211,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 43,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -200,6 +221,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 45,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -210,6 +232,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 47,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -220,6 +243,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 49,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -230,6 +254,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 52,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -241,6 +266,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 53,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -252,6 +278,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 56,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -260,6 +287,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 61,
    "metadata": {},
    "source": [
     "### NumPy Arrays and PyTorch Tensors"
@@ -268,6 +296,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 65,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -279,6 +308,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 66,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -288,6 +318,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 67,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -297,6 +328,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 69,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -306,6 +338,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 71,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -315,6 +348,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 73,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -324,6 +358,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 75,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -333,6 +368,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 77,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -342,6 +378,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 79,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -350,6 +387,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 81,
    "metadata": {},
    "source": [
     "## Computing Metrics Using Broadcasting"
@@ -358,6 +396,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 83,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -373,6 +412,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 85,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -383,6 +423,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 87,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -393,6 +434,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 89,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -402,6 +444,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 91,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -411,6 +454,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 93,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -420,6 +464,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 95,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -429,6 +474,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 97,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -438,6 +484,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 99,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -449,6 +496,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 101,
    "metadata": {},
    "source": [
     "## Stochastic Gradient Descent (SGD)"
@@ -457,6 +505,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 105,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -469,6 +518,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 108,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -478,6 +528,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 110,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -487,6 +538,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 112,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -496,6 +548,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 118,
    "metadata": {},
    "source": [
     "### Calculating Gradients"
@@ -504,6 +557,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 121,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -513,6 +567,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 123,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -523,6 +578,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 125,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -532,6 +588,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 128,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -541,6 +598,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 130,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -551,6 +609,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 132,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -563,6 +622,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 134,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -572,6 +632,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 136,
    "metadata": {},
    "source": [
     "### Stepping With a Learning Rate"
@@ -579,6 +640,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 144,
    "metadata": {},
    "source": [
     "### An End-to-End SGD Example"
@@ -587,6 +649,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 146,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -596,6 +659,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 147,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -606,6 +670,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 149,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -617,6 +682,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 151,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -625,6 +691,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 153,
    "metadata": {},
    "source": [
     "#### Step 1: Initialize the parameters"
@@ -633,6 +700,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 155,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -642,6 +710,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 156,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -651,6 +720,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 157,
    "metadata": {},
    "source": [
     "#### Step 2: Calculate the predictions"
@@ -659,6 +729,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 159,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -668,6 +739,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 161,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -681,6 +753,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 162,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -689,6 +762,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 164,
    "metadata": {},
    "source": [
     "#### Step 3: Calculate the loss"
@@ -697,6 +771,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 166,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -706,6 +781,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 168,
    "metadata": {},
    "source": [
     "#### Step 4: Calculate the gradients"
@@ -714,6 +790,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 170,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -724,6 +801,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 171,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -733,6 +811,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 173,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -741,6 +820,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 174,
    "metadata": {},
    "source": [
     "#### Step 5: Step the weights. "
@@ -749,6 +829,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 176,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -760,6 +841,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 179,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -770,6 +852,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 181,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -779,6 +862,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 183,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -794,6 +878,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 184,
    "metadata": {},
    "source": [
     "#### Step 6: Repeat the process "
@@ -802,6 +887,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 186,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -811,6 +897,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 187,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -821,6 +908,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 189,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -831,6 +919,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 190,
    "metadata": {},
    "source": [
     "#### Step 7: stop"
@@ -838,6 +927,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 192,
    "metadata": {},
    "source": [
     "### Summarizing Gradient Descent"
@@ -846,6 +936,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 193,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -857,6 +948,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 195,
    "metadata": {},
    "source": [
     "## The MNIST Loss Function"
@@ -865,6 +957,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 197,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -874,6 +967,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 199,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -884,6 +978,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 201,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -895,6 +990,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 202,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -906,6 +1002,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 204,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -915,6 +1012,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 205,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -924,6 +1022,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 207,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -933,6 +1032,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 211,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -942,6 +1042,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 215,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -953,6 +1054,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 218,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -963,6 +1065,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 219,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -972,6 +1075,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 221,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -981,6 +1085,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 222,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -991,6 +1096,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 225,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1001,6 +1107,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 227,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1011,6 +1118,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 230,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1020,6 +1128,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 232,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1029,6 +1138,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 234,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1037,6 +1147,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 236,
    "metadata": {},
    "source": [
     "### Sigmoid"
@@ -1045,6 +1156,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 238,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1054,6 +1166,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 240,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1063,6 +1176,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 242,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1073,6 +1187,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 244,
    "metadata": {},
    "source": [
     "### SGD and Mini-Batches"
@@ -1081,6 +1196,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 246,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1092,6 +1208,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 248,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1102,6 +1219,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 250,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1111,6 +1229,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 252,
    "metadata": {},
    "source": [
     "## Putting It All Together"
@@ -1119,6 +1238,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 255,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1129,6 +1249,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 257,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1140,6 +1261,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 259,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1149,6 +1271,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 261,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1159,6 +1282,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 262,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1169,6 +1293,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 263,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1179,6 +1304,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 265,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1189,6 +1315,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 267,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1201,6 +1328,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 269,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1211,6 +1339,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 271,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1221,6 +1350,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 273,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1231,6 +1361,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 276,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1245,6 +1376,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 278,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1254,6 +1386,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 280,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1266,6 +1399,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 282,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1275,6 +1409,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 284,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1286,6 +1421,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 285,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1295,6 +1431,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 287,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1307,6 +1444,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 289,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1317,6 +1455,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 291,
    "metadata": {},
    "source": [
     "### Creating an Optimizer"
@@ -1325,6 +1464,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 293,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1334,6 +1474,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 295,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1344,6 +1485,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 297,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1360,6 +1502,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 299,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1369,6 +1512,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 301,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1382,6 +1526,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 303,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1391,6 +1536,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 305,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1403,6 +1549,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 307,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1412,6 +1559,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 309,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1423,6 +1571,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 311,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1432,6 +1581,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 313,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1442,6 +1592,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 315,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1450,6 +1601,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 317,
    "metadata": {},
    "source": [
     "## Adding a Nonlinearity"
@@ -1458,6 +1610,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 319,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1471,6 +1624,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 321,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1483,6 +1637,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 323,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1492,6 +1647,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 328,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1505,6 +1661,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 330,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1515,6 +1672,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 331,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1524,6 +1682,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 333,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1533,6 +1692,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 335,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1541,6 +1701,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 337,
    "metadata": {},
    "source": [
     "### Going Deeper"
@@ -1549,6 +1710,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 339,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1560,6 +1722,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 341,
    "metadata": {},
    "source": [
     "## Jargon Recap"
@@ -1567,6 +1730,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 344,
    "metadata": {},
    "source": [
     "## Questionnaire"
@@ -1574,6 +1738,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 345,
    "metadata": {},
    "source": [
     "1. How is a grayscale image represented on a computer? How about a color image?\n",
@@ -1617,6 +1782,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 346,
    "metadata": {},
    "source": [
     "### Further Research"
@@ -1624,6 +1790,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 347,
    "metadata": {},
    "source": [
     "1. Create your own implementation of `Learner` from scratch, based on the training loop shown in this chapter.\n",
@@ -1633,6 +1800,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 348,
    "metadata": {},
    "outputs": [],
    "source": []
@@ -1643,11 +1811,12 @@
    "split_at_heading": true
   },
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "python3",
    "language": "python",
    "name": "python3"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 4
+ "nbformat_minor": 4,
+ "path_": "04_mnist_basics.ipynb"
 }

--- a/clean/04_mnist_basics.ipynb
+++ b/clean/04_mnist_basics.ipynb
@@ -3,7 +3,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 0,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -16,7 +15,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 1,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -29,7 +27,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 3,
    "metadata": {},
    "source": [
     "# Under the Hood: Training a Digit Classifier"
@@ -37,7 +34,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 5,
    "metadata": {},
    "source": [
     "## Pixels: The Foundations of Computer Vision"
@@ -45,7 +41,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 7,
    "metadata": {},
    "source": [
     "## Sidebar: Tenacity and Deep Learning"
@@ -53,7 +48,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 9,
    "metadata": {},
    "source": [
     "## End sidebar"
@@ -62,7 +56,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 11,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -72,7 +65,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 12,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -83,7 +75,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 14,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -93,7 +84,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 16,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -103,7 +93,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 18,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -115,7 +104,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 20,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -127,7 +115,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 22,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -137,7 +124,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 24,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -147,7 +133,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 26,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -158,7 +143,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 29,
    "metadata": {},
    "source": [
     "## First Try: Pixel Similarity"
@@ -167,7 +151,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 33,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -179,7 +162,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 36,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -189,7 +171,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 38,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -201,7 +182,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 40,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -211,7 +191,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 43,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -221,7 +200,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 45,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -232,7 +210,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 47,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -243,7 +220,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 49,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -254,7 +230,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 52,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -266,7 +241,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 53,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -278,7 +252,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 56,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -287,7 +260,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 61,
    "metadata": {},
    "source": [
     "### NumPy Arrays and PyTorch Tensors"
@@ -296,7 +268,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 65,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -308,7 +279,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 66,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -318,7 +288,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 67,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -328,7 +297,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 69,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -338,7 +306,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 71,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -348,7 +315,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 73,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -358,7 +324,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 75,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -368,7 +333,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 77,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -378,7 +342,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 79,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -387,7 +350,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 81,
    "metadata": {},
    "source": [
     "## Computing Metrics Using Broadcasting"
@@ -396,7 +358,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 83,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -412,7 +373,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 85,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -423,7 +383,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 87,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -434,7 +393,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 89,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -444,7 +402,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 91,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -454,7 +411,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 93,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -464,7 +420,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 95,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -474,7 +429,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 97,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -484,7 +438,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 99,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -496,7 +449,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 101,
    "metadata": {},
    "source": [
     "## Stochastic Gradient Descent (SGD)"
@@ -505,7 +457,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 105,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -518,7 +469,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 108,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -528,7 +478,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 110,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -538,7 +487,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 112,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -548,7 +496,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 118,
    "metadata": {},
    "source": [
     "### Calculating Gradients"
@@ -557,7 +504,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 121,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -567,7 +513,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 123,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -578,7 +523,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 125,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -588,7 +532,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 128,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -598,7 +541,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 130,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -609,7 +551,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 132,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -622,7 +563,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 134,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -632,7 +572,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 136,
    "metadata": {},
    "source": [
     "### Stepping With a Learning Rate"
@@ -640,7 +579,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 144,
    "metadata": {},
    "source": [
     "### An End-to-End SGD Example"
@@ -649,7 +587,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 146,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -659,7 +596,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 147,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -670,7 +606,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 149,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -682,7 +617,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 151,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -691,7 +625,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 153,
    "metadata": {},
    "source": [
     "#### Step 1: Initialize the parameters"
@@ -700,7 +633,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 155,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -710,7 +642,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 156,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -720,7 +651,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 157,
    "metadata": {},
    "source": [
     "#### Step 2: Calculate the predictions"
@@ -729,7 +659,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 159,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -739,7 +668,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 161,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -753,7 +681,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 162,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -762,7 +689,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 164,
    "metadata": {},
    "source": [
     "#### Step 3: Calculate the loss"
@@ -771,7 +697,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 166,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -781,7 +706,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 168,
    "metadata": {},
    "source": [
     "#### Step 4: Calculate the gradients"
@@ -790,7 +714,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 170,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -801,7 +724,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 171,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -811,7 +733,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 173,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -820,7 +741,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 174,
    "metadata": {},
    "source": [
     "#### Step 5: Step the weights. "
@@ -829,7 +749,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 176,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -841,7 +760,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 179,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -852,7 +770,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 181,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -862,7 +779,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 183,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -878,7 +794,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 184,
    "metadata": {},
    "source": [
     "#### Step 6: Repeat the process "
@@ -887,7 +802,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 186,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -897,7 +811,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 187,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -908,7 +821,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 189,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -919,7 +831,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 190,
    "metadata": {},
    "source": [
     "#### Step 7: stop"
@@ -927,7 +838,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 192,
    "metadata": {},
    "source": [
     "### Summarizing Gradient Descent"
@@ -936,7 +846,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 193,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -948,7 +857,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 195,
    "metadata": {},
    "source": [
     "## The MNIST Loss Function"
@@ -957,7 +865,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 197,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -967,7 +874,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 199,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -978,7 +884,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 201,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -990,7 +895,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 202,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1002,7 +906,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 204,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1012,7 +915,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 205,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1022,7 +924,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 207,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1032,7 +933,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 211,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1042,7 +942,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 215,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1054,7 +953,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 218,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1065,7 +963,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 219,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1075,7 +972,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 221,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1085,7 +981,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 222,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1096,7 +991,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 225,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1107,7 +1001,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 227,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1118,7 +1011,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 230,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1128,7 +1020,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 232,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1138,7 +1029,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 234,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1147,7 +1037,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 236,
    "metadata": {},
    "source": [
     "### Sigmoid"
@@ -1156,7 +1045,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 238,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1166,7 +1054,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 240,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1176,7 +1063,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 242,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1187,7 +1073,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 244,
    "metadata": {},
    "source": [
     "### SGD and Mini-Batches"
@@ -1196,7 +1081,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 246,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1208,7 +1092,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 248,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1219,7 +1102,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 250,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1229,7 +1111,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 252,
    "metadata": {},
    "source": [
     "## Putting It All Together"
@@ -1238,7 +1119,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 255,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1249,7 +1129,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 257,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1261,7 +1140,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 259,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1271,7 +1149,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 261,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1282,7 +1159,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 262,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1293,7 +1169,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 263,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1304,7 +1179,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 265,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1315,7 +1189,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 267,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1328,7 +1201,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 269,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1339,7 +1211,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 271,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1350,7 +1221,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 273,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1361,7 +1231,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 276,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1376,7 +1245,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 278,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1386,7 +1254,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 280,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1399,7 +1266,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 282,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1409,7 +1275,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 284,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1421,7 +1286,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 285,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1431,7 +1295,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 287,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1444,7 +1307,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 289,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1455,7 +1317,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 291,
    "metadata": {},
    "source": [
     "### Creating an Optimizer"
@@ -1464,7 +1325,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 293,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1474,7 +1334,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 295,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1485,7 +1344,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 297,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1502,7 +1360,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 299,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1512,7 +1369,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 301,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1526,7 +1382,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 303,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1536,7 +1391,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 305,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1549,7 +1403,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 307,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1559,7 +1412,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 309,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1571,7 +1423,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 311,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1581,7 +1432,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 313,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1592,7 +1442,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 315,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1601,7 +1450,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 317,
    "metadata": {},
    "source": [
     "## Adding a Nonlinearity"
@@ -1610,7 +1458,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 319,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1624,7 +1471,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 321,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1637,7 +1483,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 323,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1647,7 +1492,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 328,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1661,7 +1505,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 330,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1672,7 +1515,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 331,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1682,7 +1524,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 333,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1692,7 +1533,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 335,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1701,7 +1541,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 337,
    "metadata": {},
    "source": [
     "### Going Deeper"
@@ -1710,7 +1549,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 339,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1722,7 +1560,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 341,
    "metadata": {},
    "source": [
     "## Jargon Recap"
@@ -1730,7 +1567,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 344,
    "metadata": {},
    "source": [
     "## Questionnaire"
@@ -1738,7 +1574,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 345,
    "metadata": {},
    "source": [
     "1. How is a grayscale image represented on a computer? How about a color image?\n",
@@ -1782,7 +1617,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 346,
    "metadata": {},
    "source": [
     "### Further Research"
@@ -1790,7 +1624,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 347,
    "metadata": {},
    "source": [
     "1. Create your own implementation of `Learner` from scratch, based on the training loop shown in this chapter.\n",
@@ -1800,7 +1633,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 348,
    "metadata": {},
    "outputs": [],
    "source": []
@@ -1817,6 +1649,5 @@
   }
  },
  "nbformat": 4,
- "nbformat_minor": 4,
- "path_": "04_mnist_basics.ipynb"
+ "nbformat_minor": 4
 }

--- a/clean/05_pet_breeds.ipynb
+++ b/clean/05_pet_breeds.ipynb
@@ -3,6 +3,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 0,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -15,6 +16,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 1,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -24,6 +26,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 3,
    "metadata": {},
    "source": [
     "# Image Classification"
@@ -31,6 +34,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 5,
    "metadata": {},
    "source": [
     "## From Dogs and Cats to Pet Breeds"
@@ -39,6 +43,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 7,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -49,6 +54,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 9,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -59,6 +65,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 10,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -68,6 +75,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 12,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -77,6 +85,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 14,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -86,6 +95,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 16,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -95,6 +105,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 18,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -109,6 +120,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 20,
    "metadata": {},
    "source": [
     "## Presizing"
@@ -117,6 +129,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 24,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -145,6 +158,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 26,
    "metadata": {},
    "source": [
     "### Checking and Debugging a DataBlock"
@@ -153,6 +167,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 28,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -162,6 +177,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 30,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -175,6 +191,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 33,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -184,6 +201,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 35,
    "metadata": {},
    "source": [
     "## Cross-Entropy Loss"
@@ -191,6 +209,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 37,
    "metadata": {},
    "source": [
     "### Viewing Activations and Labels"
@@ -199,6 +218,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 39,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -208,6 +228,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 41,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -217,6 +238,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 43,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -227,6 +249,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 45,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -235,6 +258,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 47,
    "metadata": {},
    "source": [
     "### Softmax"
@@ -243,6 +267,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 49,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -252,6 +277,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 51,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -262,6 +288,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 52,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -272,6 +299,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 54,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -281,6 +309,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 56,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -290,6 +319,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 60,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -299,6 +329,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 64,
    "metadata": {},
    "source": [
     "### Log Likelihood"
@@ -307,6 +338,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 66,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -316,6 +348,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 68,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -325,6 +358,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 70,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -335,6 +369,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 72,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -353,6 +388,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 75,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -362,6 +398,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 76,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -370,6 +407,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 79,
    "metadata": {},
    "source": [
     "#### Taking the Log\n",
@@ -380,6 +418,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 80,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -389,6 +428,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 83,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -398,6 +438,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 86,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -412,6 +453,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 89,
    "metadata": {},
    "source": [
     "### Negative Log Likelihood"
@@ -420,6 +462,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 92,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -429,6 +472,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 94,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -438,6 +482,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 96,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -447,6 +492,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 98,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -455,6 +501,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 102,
    "metadata": {},
    "source": [
     "## Model Interpretation"
@@ -463,6 +510,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 104,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -473,6 +521,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 106,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -481,6 +530,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 108,
    "metadata": {},
    "source": [
     "## Improving Our Model"
@@ -488,6 +538,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 110,
    "metadata": {},
    "source": [
     "### The Learning Rate Finder"
@@ -496,6 +547,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 112,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -506,6 +558,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 114,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -516,6 +569,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 115,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -525,6 +579,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 117,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -534,6 +589,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 121,
    "metadata": {},
    "source": [
     "### Unfreezing and Transfer Learning"
@@ -542,6 +598,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 124,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -551,6 +608,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 125,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -561,6 +619,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 127,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -570,6 +629,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 129,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -579,6 +639,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 131,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -587,6 +648,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 133,
    "metadata": {},
    "source": [
     "### Discriminative Learning Rates"
@@ -595,6 +657,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 137,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -607,6 +670,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 139,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -615,6 +679,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 142,
    "metadata": {},
    "source": [
     "### Selecting the Number of Epochs"
@@ -622,6 +687,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 144,
    "metadata": {},
    "source": [
     "### Deeper Architectures"
@@ -630,6 +696,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 146,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -640,6 +707,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 148,
    "metadata": {},
    "source": [
     "## Conclusion"
@@ -647,6 +715,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 150,
    "metadata": {},
    "source": [
     "## Questionnaire"
@@ -654,6 +723,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 151,
    "metadata": {},
    "source": [
     "1. Why do we first resize to a large size on the CPU, and then to a smaller size on the GPU?\n",
@@ -683,6 +753,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 152,
    "metadata": {},
    "source": [
     "### Further Research"
@@ -690,6 +761,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 153,
    "metadata": {},
    "source": [
     "1. Find the paper by Leslie Smith that introduced the learning rate finder, and read it.\n",
@@ -699,6 +771,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 154,
    "metadata": {},
    "outputs": [],
    "source": []
@@ -709,11 +782,12 @@
    "split_at_heading": true
   },
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "python3",
    "language": "python",
    "name": "python3"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 4
+ "nbformat_minor": 4,
+ "path_": "05_pet_breeds.ipynb"
 }

--- a/clean/05_pet_breeds.ipynb
+++ b/clean/05_pet_breeds.ipynb
@@ -3,7 +3,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 0,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -16,7 +15,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 1,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -26,7 +24,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 3,
    "metadata": {},
    "source": [
     "# Image Classification"
@@ -34,7 +31,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 5,
    "metadata": {},
    "source": [
     "## From Dogs and Cats to Pet Breeds"
@@ -43,7 +39,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 7,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -54,7 +49,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 9,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -65,7 +59,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 10,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -75,7 +68,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 12,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -85,7 +77,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 14,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -95,7 +86,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 16,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -105,7 +95,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 18,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -120,7 +109,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 20,
    "metadata": {},
    "source": [
     "## Presizing"
@@ -129,7 +117,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 24,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -158,7 +145,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 26,
    "metadata": {},
    "source": [
     "### Checking and Debugging a DataBlock"
@@ -167,7 +153,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 28,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -177,7 +162,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 30,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -191,7 +175,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 33,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -201,7 +184,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 35,
    "metadata": {},
    "source": [
     "## Cross-Entropy Loss"
@@ -209,7 +191,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 37,
    "metadata": {},
    "source": [
     "### Viewing Activations and Labels"
@@ -218,7 +199,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 39,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -228,7 +208,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 41,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -238,7 +217,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 43,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -249,7 +227,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 45,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -258,7 +235,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 47,
    "metadata": {},
    "source": [
     "### Softmax"
@@ -267,7 +243,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 49,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -277,7 +252,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 51,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -288,7 +262,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 52,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -299,7 +272,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 54,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -309,7 +281,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 56,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -319,7 +290,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 60,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -329,7 +299,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 64,
    "metadata": {},
    "source": [
     "### Log Likelihood"
@@ -338,7 +307,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 66,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -348,7 +316,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 68,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -358,7 +325,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 70,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -369,7 +335,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 72,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -388,7 +353,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 75,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -398,7 +362,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 76,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -407,7 +370,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 79,
    "metadata": {},
    "source": [
     "#### Taking the Log\n",
@@ -418,7 +380,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 80,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -428,7 +389,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 83,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -438,7 +398,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 86,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -453,7 +412,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 89,
    "metadata": {},
    "source": [
     "### Negative Log Likelihood"
@@ -462,7 +420,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 92,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -472,7 +429,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 94,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -482,7 +438,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 96,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -492,7 +447,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 98,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -501,7 +455,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 102,
    "metadata": {},
    "source": [
     "## Model Interpretation"
@@ -510,7 +463,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 104,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -521,7 +473,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 106,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -530,7 +481,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 108,
    "metadata": {},
    "source": [
     "## Improving Our Model"
@@ -538,7 +488,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 110,
    "metadata": {},
    "source": [
     "### The Learning Rate Finder"
@@ -547,7 +496,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 112,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -558,7 +506,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 114,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -569,7 +516,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 115,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -579,7 +525,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 117,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -589,7 +534,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 121,
    "metadata": {},
    "source": [
     "### Unfreezing and Transfer Learning"
@@ -598,7 +542,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 124,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -608,7 +551,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 125,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -619,7 +561,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 127,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -629,7 +570,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 129,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -639,7 +579,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 131,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -648,7 +587,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 133,
    "metadata": {},
    "source": [
     "### Discriminative Learning Rates"
@@ -657,7 +595,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 137,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -670,7 +607,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 139,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -679,7 +615,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 142,
    "metadata": {},
    "source": [
     "### Selecting the Number of Epochs"
@@ -687,7 +622,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 144,
    "metadata": {},
    "source": [
     "### Deeper Architectures"
@@ -696,7 +630,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 146,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -707,7 +640,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 148,
    "metadata": {},
    "source": [
     "## Conclusion"
@@ -715,7 +647,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 150,
    "metadata": {},
    "source": [
     "## Questionnaire"
@@ -723,7 +654,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 151,
    "metadata": {},
    "source": [
     "1. Why do we first resize to a large size on the CPU, and then to a smaller size on the GPU?\n",
@@ -753,7 +683,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 152,
    "metadata": {},
    "source": [
     "### Further Research"
@@ -761,7 +690,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 153,
    "metadata": {},
    "source": [
     "1. Find the paper by Leslie Smith that introduced the learning rate finder, and read it.\n",
@@ -771,7 +699,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 154,
    "metadata": {},
    "outputs": [],
    "source": []
@@ -788,6 +715,5 @@
   }
  },
  "nbformat": 4,
- "nbformat_minor": 4,
- "path_": "05_pet_breeds.ipynb"
+ "nbformat_minor": 4
 }

--- a/clean/06_multicat.ipynb
+++ b/clean/06_multicat.ipynb
@@ -3,7 +3,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 0,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -16,7 +15,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 1,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -26,7 +24,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 3,
    "metadata": {},
    "source": [
     "# Other Computer Vision Problems"
@@ -34,7 +31,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 5,
    "metadata": {},
    "source": [
     "## Multi-Label Classification"
@@ -42,7 +38,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 7,
    "metadata": {},
    "source": [
     "### The Data"
@@ -51,7 +46,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 9,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -62,7 +56,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 11,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -72,7 +65,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 13,
    "metadata": {},
    "source": [
     "### Sidebar: Pandas and DataFrames"
@@ -81,7 +73,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 15,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -91,7 +82,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 16,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -104,7 +94,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 18,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -114,7 +103,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 20,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -125,7 +113,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 21,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -135,7 +122,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 23,
    "metadata": {},
    "source": [
     "### End sidebar"
@@ -143,7 +129,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 25,
    "metadata": {},
    "source": [
     "### Constructing a DataBlock"
@@ -152,7 +137,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 29,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -162,7 +146,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 31,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -172,7 +155,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 33,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -182,7 +164,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 34,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -193,7 +174,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 36,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -203,7 +183,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 37,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -215,7 +194,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 39,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -229,7 +207,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 42,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -243,7 +220,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 44,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -256,7 +232,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 48,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -267,7 +242,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 50,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -288,7 +262,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 52,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -303,7 +276,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 54,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -312,7 +284,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 57,
    "metadata": {},
    "source": [
     "### Binary Cross-Entropy"
@@ -321,7 +292,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 59,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -331,7 +301,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 61,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -343,7 +312,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 63,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -353,7 +321,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 66,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -365,7 +332,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 70,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -377,7 +343,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 73,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -388,7 +353,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 75,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -399,7 +363,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 77,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -410,7 +373,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 79,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -421,7 +383,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 81,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -432,7 +393,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 83,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -442,7 +402,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 85,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -452,7 +411,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 87,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -463,7 +421,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 89,
    "metadata": {},
    "source": [
     "## Regression"
@@ -471,7 +428,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 91,
    "metadata": {},
    "source": [
     "### Assemble the Data"
@@ -480,7 +436,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 93,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -490,7 +445,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 94,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -501,7 +455,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 96,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -511,7 +464,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 98,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -521,7 +473,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 100,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -533,7 +484,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 102,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -544,7 +494,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 103,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -554,7 +503,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 105,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -569,7 +517,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 107,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -579,7 +526,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 109,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -595,7 +541,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 112,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -606,7 +551,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 114,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -617,7 +561,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 117,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -626,7 +569,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 120,
    "metadata": {},
    "source": [
     "### Training a Model"
@@ -635,7 +577,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 122,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -645,7 +586,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 124,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -655,7 +595,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 126,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -665,7 +604,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 128,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -675,7 +613,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 130,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -685,7 +622,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 132,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -696,7 +632,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 134,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -706,7 +641,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 136,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -715,7 +649,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 138,
    "metadata": {},
    "source": [
     "## Conclusion"
@@ -723,7 +656,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 140,
    "metadata": {},
    "source": [
     "## Questionnaire"
@@ -731,7 +663,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 141,
    "metadata": {},
    "source": [
     "1. How could multi-label classification improve the usability of the bear classifier?\n",
@@ -755,7 +686,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 142,
    "metadata": {},
    "source": [
     "### Further Research"
@@ -763,7 +693,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 143,
    "metadata": {},
    "source": [
     "1. Read a tutorial about Pandas DataFrames and experiment with a few methods that look interesting to you. See the book's website for recommended tutorials.\n",
@@ -773,7 +702,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 144,
    "metadata": {},
    "outputs": [],
    "source": []
@@ -790,6 +718,5 @@
   }
  },
  "nbformat": 4,
- "nbformat_minor": 4,
- "path_": "06_multicat.ipynb"
+ "nbformat_minor": 4
 }

--- a/clean/06_multicat.ipynb
+++ b/clean/06_multicat.ipynb
@@ -3,6 +3,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 0,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -15,6 +16,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 1,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -24,6 +26,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 3,
    "metadata": {},
    "source": [
     "# Other Computer Vision Problems"
@@ -31,6 +34,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 5,
    "metadata": {},
    "source": [
     "## Multi-Label Classification"
@@ -38,6 +42,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 7,
    "metadata": {},
    "source": [
     "### The Data"
@@ -46,6 +51,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 9,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -56,6 +62,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 11,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -65,6 +72,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 13,
    "metadata": {},
    "source": [
     "### Sidebar: Pandas and DataFrames"
@@ -73,6 +81,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 15,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -82,6 +91,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 16,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -94,6 +104,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 18,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -103,6 +114,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 20,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -113,6 +125,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 21,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -122,6 +135,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 23,
    "metadata": {},
    "source": [
     "### End sidebar"
@@ -129,6 +143,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 25,
    "metadata": {},
    "source": [
     "### Constructing a DataBlock"
@@ -137,6 +152,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 29,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -146,6 +162,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 31,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -155,6 +172,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 33,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -164,6 +182,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 34,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -174,6 +193,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 36,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -183,6 +203,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 37,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -194,6 +215,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 39,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -207,6 +229,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 42,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -220,6 +243,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 44,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -232,6 +256,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 48,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -242,6 +267,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 50,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -262,6 +288,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 52,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -276,6 +303,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 54,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -284,6 +312,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 57,
    "metadata": {},
    "source": [
     "### Binary Cross-Entropy"
@@ -292,6 +321,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 59,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -301,6 +331,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 61,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -312,6 +343,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 63,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -321,6 +353,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 66,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -332,6 +365,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 70,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -343,6 +377,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 73,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -353,6 +388,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 75,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -363,6 +399,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 77,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -373,6 +410,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 79,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -383,6 +421,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 81,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -393,6 +432,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 83,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -402,6 +442,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 85,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -411,6 +452,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 87,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -421,6 +463,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 89,
    "metadata": {},
    "source": [
     "## Regression"
@@ -428,6 +471,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 91,
    "metadata": {},
    "source": [
     "### Assemble the Data"
@@ -436,6 +480,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 93,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -445,6 +490,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 94,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -455,6 +501,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 96,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -464,6 +511,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 98,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -473,6 +521,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 100,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -484,6 +533,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 102,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -494,6 +544,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 103,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -503,6 +554,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 105,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -517,6 +569,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 107,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -526,6 +579,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 109,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -541,6 +595,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 112,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -551,6 +606,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 114,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -561,6 +617,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 117,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -569,6 +626,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 120,
    "metadata": {},
    "source": [
     "### Training a Model"
@@ -577,6 +635,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 122,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -586,6 +645,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 124,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -595,6 +655,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 126,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -604,6 +665,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 128,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -613,6 +675,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 130,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -622,6 +685,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 132,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -632,6 +696,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 134,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -641,6 +706,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 136,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -649,6 +715,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 138,
    "metadata": {},
    "source": [
     "## Conclusion"
@@ -656,6 +723,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 140,
    "metadata": {},
    "source": [
     "## Questionnaire"
@@ -663,6 +731,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 141,
    "metadata": {},
    "source": [
     "1. How could multi-label classification improve the usability of the bear classifier?\n",
@@ -686,6 +755,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 142,
    "metadata": {},
    "source": [
     "### Further Research"
@@ -693,6 +763,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 143,
    "metadata": {},
    "source": [
     "1. Read a tutorial about Pandas DataFrames and experiment with a few methods that look interesting to you. See the book's website for recommended tutorials.\n",
@@ -702,6 +773,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 144,
    "metadata": {},
    "outputs": [],
    "source": []
@@ -712,11 +784,12 @@
    "split_at_heading": true
   },
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "python3",
    "language": "python",
    "name": "python3"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 4
+ "nbformat_minor": 4,
+ "path_": "06_multicat.ipynb"
 }

--- a/clean/07_sizing_and_tta.ipynb
+++ b/clean/07_sizing_and_tta.ipynb
@@ -3,7 +3,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 0,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -16,7 +15,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 1,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -26,7 +24,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 3,
    "metadata": {},
    "source": [
     "# Training a State-of-the-Art Model"
@@ -34,7 +31,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 5,
    "metadata": {},
    "source": [
     "## Imagenette"
@@ -43,7 +39,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 7,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -54,7 +49,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 9,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -69,7 +63,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 11,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -80,7 +73,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 13,
    "metadata": {},
    "source": [
     "## Normalization"
@@ -89,7 +81,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 15,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -100,7 +91,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 17,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -117,7 +107,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 18,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -127,7 +116,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 19,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -138,7 +126,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 21,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -149,7 +136,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 23,
    "metadata": {},
    "source": [
     "## Progressive Resizing"
@@ -158,7 +144,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 27,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -171,7 +156,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 29,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -181,7 +165,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 31,
    "metadata": {},
    "source": [
     "## Test Time Augmentation"
@@ -190,7 +173,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 35,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -200,7 +182,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 37,
    "metadata": {},
    "source": [
     "## Mixup"
@@ -208,7 +189,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 40,
    "metadata": {},
    "source": [
     "### Sidebar: Papers and Math"
@@ -216,7 +196,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 42,
    "metadata": {},
    "source": [
     "### End sidebar"
@@ -225,7 +204,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 44,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -244,7 +222,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 48,
    "metadata": {},
    "source": [
     "## Label Smoothing"
@@ -252,7 +229,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 50,
    "metadata": {},
    "source": [
     "### Sidebar: Label Smoothing, the Paper"
@@ -260,7 +236,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 53,
    "metadata": {},
    "source": [
     "### End sidebar"
@@ -268,7 +243,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 55,
    "metadata": {},
    "source": [
     "## Conclusion"
@@ -276,7 +250,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 57,
    "metadata": {},
    "source": [
     "## Questionnaire"
@@ -284,7 +257,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 58,
    "metadata": {},
    "source": [
     "1. What is the difference between ImageNet and Imagenette? When is it better to experiment on one versus the other?\n",
@@ -305,7 +277,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 59,
    "metadata": {},
    "source": [
     "### Further Research\n",
@@ -319,7 +290,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 60,
    "metadata": {},
    "outputs": [],
    "source": []
@@ -336,6 +306,5 @@
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2,
- "path_": "07_sizing_and_tta.ipynb"
+ "nbformat_minor": 2
 }

--- a/clean/07_sizing_and_tta.ipynb
+++ b/clean/07_sizing_and_tta.ipynb
@@ -3,6 +3,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 0,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -15,6 +16,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 1,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -24,6 +26,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 3,
    "metadata": {},
    "source": [
     "# Training a State-of-the-Art Model"
@@ -31,6 +34,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 5,
    "metadata": {},
    "source": [
     "## Imagenette"
@@ -39,6 +43,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 7,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -49,6 +54,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 9,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -63,6 +69,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 11,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -73,6 +80,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 13,
    "metadata": {},
    "source": [
     "## Normalization"
@@ -81,6 +89,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 15,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -91,6 +100,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 17,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -107,6 +117,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 18,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -116,6 +127,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 19,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -126,6 +138,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 21,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -136,6 +149,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 23,
    "metadata": {},
    "source": [
     "## Progressive Resizing"
@@ -144,6 +158,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 27,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -156,6 +171,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 29,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -165,6 +181,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 31,
    "metadata": {},
    "source": [
     "## Test Time Augmentation"
@@ -173,6 +190,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 35,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -182,6 +200,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 37,
    "metadata": {},
    "source": [
     "## Mixup"
@@ -189,6 +208,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 40,
    "metadata": {},
    "source": [
     "### Sidebar: Papers and Math"
@@ -196,6 +216,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 42,
    "metadata": {},
    "source": [
     "### End sidebar"
@@ -204,6 +225,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 44,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -222,6 +244,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 48,
    "metadata": {},
    "source": [
     "## Label Smoothing"
@@ -229,6 +252,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 50,
    "metadata": {},
    "source": [
     "### Sidebar: Label Smoothing, the Paper"
@@ -236,6 +260,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 53,
    "metadata": {},
    "source": [
     "### End sidebar"
@@ -243,6 +268,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 55,
    "metadata": {},
    "source": [
     "## Conclusion"
@@ -250,6 +276,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 57,
    "metadata": {},
    "source": [
     "## Questionnaire"
@@ -257,6 +284,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 58,
    "metadata": {},
    "source": [
     "1. What is the difference between ImageNet and Imagenette? When is it better to experiment on one versus the other?\n",
@@ -277,6 +305,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 59,
    "metadata": {},
    "source": [
     "### Further Research\n",
@@ -290,6 +319,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 60,
    "metadata": {},
    "outputs": [],
    "source": []
@@ -300,11 +330,12 @@
    "split_at_heading": true
   },
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "python3",
    "language": "python",
    "name": "python3"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 2,
+ "path_": "07_sizing_and_tta.ipynb"
 }

--- a/clean/08_collab.ipynb
+++ b/clean/08_collab.ipynb
@@ -3,6 +3,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 0,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -15,6 +16,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 1,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -24,6 +26,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 3,
    "metadata": {},
    "source": [
     "# Collaborative Filtering Deep Dive"
@@ -31,6 +34,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 6,
    "metadata": {},
    "source": [
     "## A First Look at the Data"
@@ -39,6 +43,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 9,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -50,6 +55,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 11,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -61,6 +67,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 15,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -70,6 +77,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 17,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -79,6 +87,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 19,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -88,6 +97,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 23,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -97,6 +107,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 25,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -105,6 +116,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 27,
    "metadata": {},
    "source": [
     "## Learning the Latent Factors"
@@ -112,6 +124,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 32,
    "metadata": {},
    "source": [
     "## Creating the DataLoaders"
@@ -120,6 +133,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 34,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -131,6 +145,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 36,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -141,6 +156,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 38,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -151,6 +167,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 40,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -160,6 +177,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 41,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -174,6 +192,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 43,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -183,6 +202,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 44,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -192,6 +212,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 46,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -200,6 +221,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 50,
    "metadata": {},
    "source": [
     "## Collaborative Filtering from Scratch"
@@ -208,6 +230,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 52,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -219,6 +242,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 54,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -229,6 +253,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 56,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -246,6 +271,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 58,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -256,6 +282,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 60,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -266,6 +293,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 62,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -275,6 +303,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 64,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -293,6 +322,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 65,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -304,6 +334,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 67,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -326,6 +357,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 69,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -336,6 +368,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 71,
    "metadata": {},
    "source": [
     "### Weight Decay"
@@ -344,6 +377,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 73,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -359,6 +393,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 75,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -369,6 +404,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 77,
    "metadata": {},
    "source": [
     "### Creating Our Own Embedding Module"
@@ -377,6 +413,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 79,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -389,6 +426,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 81,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -401,6 +439,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 83,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -414,6 +453,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 84,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -423,6 +463,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 86,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -433,6 +474,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 88,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -455,6 +497,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 90,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -465,6 +508,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 92,
    "metadata": {},
    "source": [
     "## Interpreting Embeddings and Biases"
@@ -473,6 +517,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 94,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -484,6 +529,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 96,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -494,6 +540,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 98,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -515,6 +562,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 102,
    "metadata": {},
    "source": [
     "### Using fastai.collab"
@@ -523,6 +571,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 104,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -532,6 +581,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 105,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -541,6 +591,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 107,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -550,6 +601,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 109,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -560,6 +612,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 111,
    "metadata": {},
    "source": [
     "### Embedding Distance"
@@ -568,6 +621,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 113,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -580,6 +634,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 115,
    "metadata": {},
    "source": [
     "## Bootstrapping a Collaborative Filtering Model"
@@ -587,6 +642,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 119,
    "metadata": {},
    "source": [
     "## Deep Learning for Collaborative Filtering"
@@ -595,6 +651,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 121,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -605,6 +662,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 123,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -627,6 +685,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 125,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -636,6 +695,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 127,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -646,6 +706,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 129,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -656,6 +717,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 131,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -667,6 +729,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 133,
    "metadata": {},
    "source": [
     "### Sidebar: kwargs and Delegates"
@@ -674,6 +737,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 135,
    "metadata": {},
    "source": [
     "### End sidebar"
@@ -681,6 +745,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 137,
    "metadata": {},
    "source": [
     "## Conclusion"
@@ -688,6 +753,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 139,
    "metadata": {},
    "source": [
     "## Questionnaire"
@@ -695,6 +761,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 140,
    "metadata": {},
    "source": [
     "1. What problem does collaborative filtering solve?\n",
@@ -732,6 +799,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 141,
    "metadata": {},
    "source": [
     "### Further Research\n",
@@ -745,6 +813,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 142,
    "metadata": {},
    "outputs": [],
    "source": []
@@ -755,11 +824,12 @@
    "split_at_heading": true
   },
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "python3",
    "language": "python",
    "name": "python3"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 2,
+ "path_": "08_collab.ipynb"
 }

--- a/clean/08_collab.ipynb
+++ b/clean/08_collab.ipynb
@@ -3,7 +3,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 0,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -16,7 +15,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 1,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -26,7 +24,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 3,
    "metadata": {},
    "source": [
     "# Collaborative Filtering Deep Dive"
@@ -34,7 +31,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 6,
    "metadata": {},
    "source": [
     "## A First Look at the Data"
@@ -43,7 +39,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 9,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -55,7 +50,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 11,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -67,7 +61,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 15,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -77,7 +70,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 17,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -87,7 +79,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 19,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -97,7 +88,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 23,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -107,7 +97,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 25,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -116,7 +105,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 27,
    "metadata": {},
    "source": [
     "## Learning the Latent Factors"
@@ -124,7 +112,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 32,
    "metadata": {},
    "source": [
     "## Creating the DataLoaders"
@@ -133,7 +120,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 34,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -145,7 +131,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 36,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -156,7 +141,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 38,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -167,7 +151,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 40,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -177,7 +160,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 41,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -192,7 +174,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 43,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -202,7 +183,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 44,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -212,7 +192,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 46,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -221,7 +200,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 50,
    "metadata": {},
    "source": [
     "## Collaborative Filtering from Scratch"
@@ -230,7 +208,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 52,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -242,7 +219,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 54,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -253,7 +229,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 56,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -271,7 +246,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 58,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -282,7 +256,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 60,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -293,7 +266,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 62,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -303,7 +275,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 64,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -322,7 +293,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 65,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -334,7 +304,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 67,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -357,7 +326,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 69,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -368,7 +336,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 71,
    "metadata": {},
    "source": [
     "### Weight Decay"
@@ -377,7 +344,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 73,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -393,7 +359,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 75,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -404,7 +369,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 77,
    "metadata": {},
    "source": [
     "### Creating Our Own Embedding Module"
@@ -413,7 +377,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 79,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -426,7 +389,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 81,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -439,7 +401,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 83,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -453,7 +414,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 84,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -463,7 +423,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 86,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -474,7 +433,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 88,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -497,7 +455,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 90,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -508,7 +465,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 92,
    "metadata": {},
    "source": [
     "## Interpreting Embeddings and Biases"
@@ -517,7 +473,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 94,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -529,7 +484,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 96,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -540,7 +494,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 98,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -562,7 +515,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 102,
    "metadata": {},
    "source": [
     "### Using fastai.collab"
@@ -571,7 +523,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 104,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -581,7 +532,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 105,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -591,7 +541,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 107,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -601,7 +550,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 109,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -612,7 +560,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 111,
    "metadata": {},
    "source": [
     "### Embedding Distance"
@@ -621,7 +568,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 113,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -634,7 +580,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 115,
    "metadata": {},
    "source": [
     "## Bootstrapping a Collaborative Filtering Model"
@@ -642,7 +587,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 119,
    "metadata": {},
    "source": [
     "## Deep Learning for Collaborative Filtering"
@@ -651,7 +595,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 121,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -662,7 +605,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 123,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -685,7 +627,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 125,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -695,7 +636,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 127,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -706,7 +646,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 129,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -717,7 +656,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 131,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -729,7 +667,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 133,
    "metadata": {},
    "source": [
     "### Sidebar: kwargs and Delegates"
@@ -737,7 +674,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 135,
    "metadata": {},
    "source": [
     "### End sidebar"
@@ -745,7 +681,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 137,
    "metadata": {},
    "source": [
     "## Conclusion"
@@ -753,7 +688,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 139,
    "metadata": {},
    "source": [
     "## Questionnaire"
@@ -761,7 +695,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 140,
    "metadata": {},
    "source": [
     "1. What problem does collaborative filtering solve?\n",
@@ -799,7 +732,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 141,
    "metadata": {},
    "source": [
     "### Further Research\n",
@@ -813,7 +745,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 142,
    "metadata": {},
    "outputs": [],
    "source": []
@@ -830,6 +761,5 @@
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2,
- "path_": "08_collab.ipynb"
+ "nbformat_minor": 2
 }

--- a/clean/09_tabular.ipynb
+++ b/clean/09_tabular.ipynb
@@ -3,6 +3,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 0,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -15,6 +16,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 1,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -33,6 +35,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 3,
    "metadata": {},
    "source": [
     "# Tabular Modeling Deep Dive"
@@ -40,6 +43,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 5,
    "metadata": {},
    "source": [
     "## Categorical Embeddings"
@@ -47,6 +51,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 21,
    "metadata": {},
    "source": [
     "## Beyond Deep Learning"
@@ -54,6 +59,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 25,
    "metadata": {},
    "source": [
     "## The Dataset"
@@ -61,6 +67,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 27,
    "metadata": {},
    "source": [
     "### Kaggle Competitions"
@@ -69,6 +76,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 29,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -78,6 +86,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 31,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -91,6 +100,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 33,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -102,6 +112,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 34,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -112,6 +123,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 36,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -127,6 +139,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 38,
    "metadata": {},
    "source": [
     "### Look at the Data"
@@ -135,6 +148,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 40,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -144,6 +158,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 41,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -153,6 +168,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 43,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -162,6 +178,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 45,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -171,6 +188,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 46,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -181,6 +199,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 48,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -190,6 +209,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 49,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -198,6 +218,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 51,
    "metadata": {},
    "source": [
     "## Decision Trees"
@@ -205,6 +226,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 56,
    "metadata": {},
    "source": [
     "### Handling Dates"
@@ -213,6 +235,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 58,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -222,6 +245,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 60,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -232,6 +256,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 62,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -240,6 +265,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 64,
    "metadata": {},
    "source": [
     "### Using TabularPandas and TabularProc"
@@ -248,6 +274,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 66,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -257,6 +284,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 68,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -270,6 +298,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 70,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -279,6 +308,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 71,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -288,6 +318,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 73,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -297,6 +328,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 75,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -306,6 +338,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 76,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -316,6 +349,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 78,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -325,6 +359,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 79,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -334,6 +369,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 81,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -343,6 +379,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 83,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -351,6 +388,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 86,
    "metadata": {},
    "source": [
     "### Creating the Decision Tree"
@@ -359,6 +397,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 88,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -369,6 +408,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 89,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -379,6 +419,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 91,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -389,6 +430,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 93,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -398,6 +440,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 96,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -410,6 +453,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 98,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -420,6 +464,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 100,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -433,6 +478,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 102,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -443,6 +489,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 104,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -453,6 +500,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 105,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -462,6 +510,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 107,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -471,6 +520,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 109,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -480,6 +530,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 111,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -491,6 +542,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 113,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -499,6 +551,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 117,
    "metadata": {},
    "source": [
     "### Categorical Variables"
@@ -506,6 +559,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 121,
    "metadata": {},
    "source": [
     "## Random Forests"
@@ -514,6 +568,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 123,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -523,6 +578,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 124,
    "metadata": {},
    "source": [
     "### Creating a Random Forest"
@@ -531,6 +587,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 126,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -544,6 +601,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 127,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -553,6 +611,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 129,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -562,6 +621,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 133,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -571,6 +631,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 135,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -580,6 +641,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 137,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -588,6 +650,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 139,
    "metadata": {},
    "source": [
     "### Out-of-Bag Error"
@@ -596,6 +659,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 141,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -604,6 +668,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 144,
    "metadata": {},
    "source": [
     "## Model Interpretation"
@@ -611,6 +676,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 146,
    "metadata": {},
    "source": [
     "### Tree Variance for Prediction Confidence"
@@ -619,6 +685,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 148,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -628,6 +695,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 149,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -637,6 +705,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 151,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -646,6 +715,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 153,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -654,6 +724,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 155,
    "metadata": {},
    "source": [
     "### Feature Importance"
@@ -662,6 +733,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 157,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -673,6 +745,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 159,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -683,6 +756,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 161,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -694,6 +768,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 163,
    "metadata": {},
    "source": [
     "### Removing Low-Importance Variables"
@@ -702,6 +777,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 165,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -712,6 +788,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 167,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -722,6 +799,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 168,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -731,6 +809,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 170,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -740,6 +819,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 172,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -749,6 +829,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 174,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -757,6 +838,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 176,
    "metadata": {},
    "source": [
     "### Removing Redundant Features"
@@ -765,6 +847,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 178,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -774,6 +857,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 180,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -787,6 +871,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 182,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -796,6 +881,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 184,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -808,6 +894,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 186,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -818,6 +905,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 188,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -828,6 +916,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 189,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -838,6 +927,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 191,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -848,6 +938,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 193,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -857,6 +948,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 195,
    "metadata": {},
    "source": [
     "### Partial Dependence"
@@ -865,6 +957,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 197,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -876,6 +969,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 199,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -885,6 +979,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 201,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -897,6 +992,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 203,
    "metadata": {},
    "source": [
     "### Data Leakage"
@@ -904,6 +1000,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 205,
    "metadata": {},
    "source": [
     "### Tree Interpreter"
@@ -912,6 +1009,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 206,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -926,6 +1024,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 209,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -935,6 +1034,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 211,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -944,6 +1044,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 213,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -953,6 +1054,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 215,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -962,6 +1064,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 218,
    "metadata": {},
    "source": [
     "## Extrapolation and Neural Networks"
@@ -969,6 +1072,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 220,
    "metadata": {},
    "source": [
     "### The Extrapolation Problem"
@@ -977,6 +1081,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 221,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -987,6 +1092,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 223,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -998,6 +1104,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 225,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1008,6 +1115,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 227,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1017,6 +1125,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 229,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1026,6 +1135,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 231,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1035,6 +1145,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 233,
    "metadata": {},
    "source": [
     "### Finding Out-of-Domain Data"
@@ -1043,6 +1154,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 235,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1056,6 +1168,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 237,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1070,6 +1183,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 239,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1084,6 +1198,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 241,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1093,6 +1208,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 243,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1104,6 +1220,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 244,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1113,6 +1230,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 246,
    "metadata": {},
    "source": [
     "### Using a Neural Network"
@@ -1121,6 +1239,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 248,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1134,6 +1253,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 250,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1143,6 +1263,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 252,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1152,6 +1273,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 254,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1161,6 +1283,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 256,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1170,6 +1293,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 258,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1182,6 +1306,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 260,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1191,6 +1316,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 262,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1202,6 +1328,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 264,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1211,6 +1338,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 266,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1221,6 +1349,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 268,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1231,6 +1360,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 269,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1240,6 +1370,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 271,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1249,6 +1380,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 273,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1259,6 +1391,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 275,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1267,6 +1400,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 276,
    "metadata": {},
    "source": [
     "### Sidebar: fastai's Tabular Classes"
@@ -1274,6 +1408,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 278,
    "metadata": {},
    "source": [
     "### End sidebar"
@@ -1281,6 +1416,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 280,
    "metadata": {},
    "source": [
     "## Ensembling"
@@ -1289,6 +1425,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 282,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1299,6 +1436,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 284,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1307,6 +1445,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 286,
    "metadata": {},
    "source": [
     "### Boosting"
@@ -1314,6 +1453,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 289,
    "metadata": {},
    "source": [
     "### Combining Embeddings with Other Methods"
@@ -1321,6 +1461,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 293,
    "metadata": {},
    "source": [
     "## Conclusion: Our Advice for Tabular Modeling"
@@ -1328,6 +1469,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 295,
    "metadata": {},
    "source": [
     "## Questionnaire"
@@ -1335,6 +1477,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 296,
    "metadata": {},
    "source": [
     "1. What is a continuous variable?\n",
@@ -1375,6 +1518,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 297,
    "metadata": {},
    "source": [
     "### Further Research"
@@ -1382,6 +1526,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 298,
    "metadata": {},
    "source": [
     "1. Pick a competition on Kaggle with tabular data (current or past) and try to adapt the techniques seen in this chapter to get the best possible results. Compare your results to the private leaderboard.\n",
@@ -1393,6 +1538,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 299,
    "metadata": {},
    "outputs": [],
    "source": []
@@ -1400,11 +1546,12 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "python3",
    "language": "python",
    "name": "python3"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 4
+ "nbformat_minor": 4,
+ "path_": "09_tabular.ipynb"
 }

--- a/clean/09_tabular.ipynb
+++ b/clean/09_tabular.ipynb
@@ -3,7 +3,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 0,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -16,7 +15,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 1,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -35,7 +33,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 3,
    "metadata": {},
    "source": [
     "# Tabular Modeling Deep Dive"
@@ -43,7 +40,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 5,
    "metadata": {},
    "source": [
     "## Categorical Embeddings"
@@ -51,7 +47,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 21,
    "metadata": {},
    "source": [
     "## Beyond Deep Learning"
@@ -59,7 +54,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 25,
    "metadata": {},
    "source": [
     "## The Dataset"
@@ -67,7 +61,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 27,
    "metadata": {},
    "source": [
     "### Kaggle Competitions"
@@ -76,7 +69,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 29,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -86,7 +78,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 31,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -100,7 +91,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 33,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -112,7 +102,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 34,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -123,7 +112,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 36,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -139,7 +127,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 38,
    "metadata": {},
    "source": [
     "### Look at the Data"
@@ -148,7 +135,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 40,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -158,7 +144,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 41,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -168,7 +153,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 43,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -178,7 +162,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 45,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -188,7 +171,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 46,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -199,7 +181,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 48,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -209,7 +190,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 49,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -218,7 +198,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 51,
    "metadata": {},
    "source": [
     "## Decision Trees"
@@ -226,7 +205,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 56,
    "metadata": {},
    "source": [
     "### Handling Dates"
@@ -235,7 +213,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 58,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -245,7 +222,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 60,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -256,7 +232,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 62,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -265,7 +240,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 64,
    "metadata": {},
    "source": [
     "### Using TabularPandas and TabularProc"
@@ -274,7 +248,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 66,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -284,7 +257,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 68,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -298,7 +270,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 70,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -308,7 +279,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 71,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -318,7 +288,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 73,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -328,7 +297,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 75,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -338,7 +306,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 76,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -349,7 +316,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 78,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -359,7 +325,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 79,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -369,7 +334,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 81,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -379,7 +343,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 83,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -388,7 +351,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 86,
    "metadata": {},
    "source": [
     "### Creating the Decision Tree"
@@ -397,7 +359,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 88,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -408,7 +369,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 89,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -419,7 +379,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 91,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -430,7 +389,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 93,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -440,7 +398,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 96,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -453,7 +410,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 98,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -464,7 +420,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 100,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -478,7 +433,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 102,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -489,7 +443,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 104,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -500,7 +453,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 105,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -510,7 +462,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 107,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -520,7 +471,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 109,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -530,7 +480,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 111,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -542,7 +491,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 113,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -551,7 +499,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 117,
    "metadata": {},
    "source": [
     "### Categorical Variables"
@@ -559,7 +506,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 121,
    "metadata": {},
    "source": [
     "## Random Forests"
@@ -568,7 +514,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 123,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -578,7 +523,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 124,
    "metadata": {},
    "source": [
     "### Creating a Random Forest"
@@ -587,7 +531,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 126,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -601,7 +544,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 127,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -611,7 +553,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 129,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -621,7 +562,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 133,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -631,7 +571,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 135,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -641,7 +580,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 137,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -650,7 +588,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 139,
    "metadata": {},
    "source": [
     "### Out-of-Bag Error"
@@ -659,7 +596,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 141,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -668,7 +604,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 144,
    "metadata": {},
    "source": [
     "## Model Interpretation"
@@ -676,7 +611,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 146,
    "metadata": {},
    "source": [
     "### Tree Variance for Prediction Confidence"
@@ -685,7 +619,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 148,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -695,7 +628,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 149,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -705,7 +637,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 151,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -715,7 +646,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 153,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -724,7 +654,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 155,
    "metadata": {},
    "source": [
     "### Feature Importance"
@@ -733,7 +662,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 157,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -745,7 +673,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 159,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -756,7 +683,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 161,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -768,7 +694,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 163,
    "metadata": {},
    "source": [
     "### Removing Low-Importance Variables"
@@ -777,7 +702,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 165,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -788,7 +712,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 167,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -799,7 +722,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 168,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -809,7 +731,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 170,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -819,7 +740,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 172,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -829,7 +749,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 174,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -838,7 +757,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 176,
    "metadata": {},
    "source": [
     "### Removing Redundant Features"
@@ -847,7 +765,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 178,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -857,7 +774,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 180,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -871,7 +787,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 182,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -881,7 +796,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 184,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -894,7 +808,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 186,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -905,7 +818,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 188,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -916,7 +828,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 189,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -927,7 +838,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 191,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -938,7 +848,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 193,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -948,7 +857,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 195,
    "metadata": {},
    "source": [
     "### Partial Dependence"
@@ -957,7 +865,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 197,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -969,7 +876,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 199,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -979,7 +885,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 201,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -992,7 +897,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 203,
    "metadata": {},
    "source": [
     "### Data Leakage"
@@ -1000,7 +904,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 205,
    "metadata": {},
    "source": [
     "### Tree Interpreter"
@@ -1009,7 +912,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 206,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1024,7 +926,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 209,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1034,7 +935,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 211,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1044,7 +944,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 213,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1054,7 +953,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 215,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1064,7 +962,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 218,
    "metadata": {},
    "source": [
     "## Extrapolation and Neural Networks"
@@ -1072,7 +969,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 220,
    "metadata": {},
    "source": [
     "### The Extrapolation Problem"
@@ -1081,7 +977,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 221,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1092,7 +987,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 223,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1104,7 +998,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 225,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1115,7 +1008,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 227,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1125,7 +1017,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 229,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1135,7 +1026,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 231,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1145,7 +1035,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 233,
    "metadata": {},
    "source": [
     "### Finding Out-of-Domain Data"
@@ -1154,7 +1043,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 235,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1168,7 +1056,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 237,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1183,7 +1070,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 239,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1198,7 +1084,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 241,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1208,7 +1093,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 243,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1220,7 +1104,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 244,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1230,7 +1113,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 246,
    "metadata": {},
    "source": [
     "### Using a Neural Network"
@@ -1239,7 +1121,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 248,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1253,7 +1134,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 250,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1263,7 +1143,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 252,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1273,7 +1152,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 254,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1283,7 +1161,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 256,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1293,7 +1170,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 258,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1306,7 +1182,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 260,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1316,7 +1191,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 262,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1328,7 +1202,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 264,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1338,7 +1211,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 266,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1349,7 +1221,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 268,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1360,7 +1231,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 269,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1370,7 +1240,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 271,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1380,7 +1249,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 273,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1391,7 +1259,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 275,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1400,7 +1267,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 276,
    "metadata": {},
    "source": [
     "### Sidebar: fastai's Tabular Classes"
@@ -1408,7 +1274,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 278,
    "metadata": {},
    "source": [
     "### End sidebar"
@@ -1416,7 +1281,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 280,
    "metadata": {},
    "source": [
     "## Ensembling"
@@ -1425,7 +1289,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 282,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1436,7 +1299,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 284,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1445,7 +1307,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 286,
    "metadata": {},
    "source": [
     "### Boosting"
@@ -1453,7 +1314,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 289,
    "metadata": {},
    "source": [
     "### Combining Embeddings with Other Methods"
@@ -1461,7 +1321,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 293,
    "metadata": {},
    "source": [
     "## Conclusion: Our Advice for Tabular Modeling"
@@ -1469,7 +1328,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 295,
    "metadata": {},
    "source": [
     "## Questionnaire"
@@ -1477,7 +1335,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 296,
    "metadata": {},
    "source": [
     "1. What is a continuous variable?\n",
@@ -1518,7 +1375,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 297,
    "metadata": {},
    "source": [
     "### Further Research"
@@ -1526,7 +1382,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 298,
    "metadata": {},
    "source": [
     "1. Pick a competition on Kaggle with tabular data (current or past) and try to adapt the techniques seen in this chapter to get the best possible results. Compare your results to the private leaderboard.\n",
@@ -1538,7 +1393,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 299,
    "metadata": {},
    "outputs": [],
    "source": []
@@ -1552,6 +1406,5 @@
   }
  },
  "nbformat": 4,
- "nbformat_minor": 4,
- "path_": "09_tabular.ipynb"
+ "nbformat_minor": 4
 }

--- a/clean/10_nlp.ipynb
+++ b/clean/10_nlp.ipynb
@@ -3,6 +3,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 0,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -15,6 +16,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 1,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -25,6 +27,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 3,
    "metadata": {},
    "source": [
     "# NLP Deep Dive: RNNs"
@@ -32,6 +35,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 9,
    "metadata": {},
    "source": [
     "## Text Preprocessing"
@@ -39,6 +43,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 12,
    "metadata": {},
    "source": [
     "### Tokenization"
@@ -46,6 +51,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 15,
    "metadata": {},
    "source": [
     "### Word Tokenization with fastai"
@@ -54,6 +60,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 17,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -64,6 +71,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 19,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -73,6 +81,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 21,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -82,6 +91,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 23,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -93,6 +103,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 25,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -102,6 +113,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 27,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -112,6 +124,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 29,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -121,6 +134,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 32,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -129,6 +143,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 34,
    "metadata": {},
    "source": [
     "### Subword Tokenization"
@@ -137,6 +152,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 36,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -146,6 +162,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 38,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -158,6 +175,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 40,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -167,6 +185,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 42,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -176,6 +195,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 44,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -184,6 +204,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 47,
    "metadata": {},
    "source": [
     "### Numericalization with fastai"
@@ -192,6 +213,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 49,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -202,6 +224,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 51,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -212,6 +235,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 53,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -223,6 +247,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 55,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -232,6 +257,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 57,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -240,6 +266,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 59,
    "metadata": {},
    "source": [
     "### Putting Our Texts into Batches for a Language Model"
@@ -248,6 +275,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 61,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -262,6 +290,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 63,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -274,6 +303,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 65,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -286,6 +316,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 67,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -298,6 +329,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 69,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -307,6 +339,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 71,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -316,6 +349,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 73,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -326,6 +360,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 75,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -335,6 +370,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 77,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -343,6 +379,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 79,
    "metadata": {},
    "source": [
     "## Training a Text Classifier"
@@ -350,6 +387,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 81,
    "metadata": {},
    "source": [
     "### Language Model Using DataBlock"
@@ -358,6 +396,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 83,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -372,6 +411,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 85,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -380,6 +420,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 87,
    "metadata": {},
    "source": [
     "### Fine-Tuning the Language Model"
@@ -388,6 +429,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 89,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -399,6 +441,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 93,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -407,6 +450,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 95,
    "metadata": {},
    "source": [
     "### Saving and Loading Models"
@@ -415,6 +459,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 97,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -424,6 +469,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 99,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -433,6 +479,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 101,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -443,6 +490,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 103,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -451,6 +499,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 106,
    "metadata": {},
    "source": [
     "### Text Generation"
@@ -459,6 +508,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 108,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -472,6 +522,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 109,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -480,6 +531,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 111,
    "metadata": {},
    "source": [
     "### Creating the Classifier DataLoaders"
@@ -488,6 +540,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 113,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -502,6 +555,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 115,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -511,6 +565,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 117,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -520,6 +575,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 119,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -529,6 +585,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 121,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -539,6 +596,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 123,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -547,6 +605,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 124,
    "metadata": {},
    "source": [
     "### Fine-Tuning the Classifier"
@@ -555,6 +614,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 126,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -564,6 +624,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 128,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -574,6 +635,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 130,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -584,6 +646,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 132,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -593,6 +656,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 134,
    "metadata": {},
    "source": [
     "## Disinformation and Language Models"
@@ -600,6 +664,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 142,
    "metadata": {},
    "source": [
     "## Conclusion"
@@ -607,6 +672,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 144,
    "metadata": {},
    "source": [
     "## Questionnaire"
@@ -614,6 +680,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 145,
    "metadata": {},
    "source": [
     "1. What is \"self-supervised learning\"?\n",
@@ -642,6 +709,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 146,
    "metadata": {},
    "source": [
     "### Further Research"
@@ -649,6 +717,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 147,
    "metadata": {},
    "source": [
     "1. See what you can learn about language models and disinformation. What are the best language models today? Take a look at some of their outputs. Do you find them convincing? How could a bad actor best use such a model to create conflict and uncertainty?\n",
@@ -658,6 +727,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 148,
    "metadata": {},
    "outputs": [],
    "source": []
@@ -668,11 +738,12 @@
    "split_at_heading": true
   },
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "python3",
    "language": "python",
    "name": "python3"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 2,
+ "path_": "10_nlp.ipynb"
 }

--- a/clean/10_nlp.ipynb
+++ b/clean/10_nlp.ipynb
@@ -3,7 +3,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 0,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -16,7 +15,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 1,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -27,7 +25,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 3,
    "metadata": {},
    "source": [
     "# NLP Deep Dive: RNNs"
@@ -35,7 +32,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 9,
    "metadata": {},
    "source": [
     "## Text Preprocessing"
@@ -43,7 +39,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 12,
    "metadata": {},
    "source": [
     "### Tokenization"
@@ -51,7 +46,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 15,
    "metadata": {},
    "source": [
     "### Word Tokenization with fastai"
@@ -60,7 +54,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 17,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -71,7 +64,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 19,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -81,7 +73,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 21,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -91,7 +82,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 23,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -103,7 +93,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 25,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -113,7 +102,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 27,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -124,7 +112,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 29,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -134,7 +121,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 32,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -143,7 +129,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 34,
    "metadata": {},
    "source": [
     "### Subword Tokenization"
@@ -152,7 +137,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 36,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -162,7 +146,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 38,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -175,7 +158,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 40,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -185,7 +167,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 42,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -195,7 +176,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 44,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -204,7 +184,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 47,
    "metadata": {},
    "source": [
     "### Numericalization with fastai"
@@ -213,7 +192,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 49,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -224,7 +202,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 51,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -235,7 +212,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 53,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -247,7 +223,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 55,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -257,7 +232,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 57,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -266,7 +240,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 59,
    "metadata": {},
    "source": [
     "### Putting Our Texts into Batches for a Language Model"
@@ -275,7 +248,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 61,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -290,7 +262,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 63,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -303,7 +274,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 65,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -316,7 +286,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 67,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -329,7 +298,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 69,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -339,7 +307,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 71,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -349,7 +316,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 73,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -360,7 +326,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 75,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -370,7 +335,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 77,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -379,7 +343,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 79,
    "metadata": {},
    "source": [
     "## Training a Text Classifier"
@@ -387,7 +350,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 81,
    "metadata": {},
    "source": [
     "### Language Model Using DataBlock"
@@ -396,7 +358,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 83,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -411,7 +372,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 85,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -420,7 +380,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 87,
    "metadata": {},
    "source": [
     "### Fine-Tuning the Language Model"
@@ -429,7 +388,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 89,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -441,7 +399,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 93,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -450,7 +407,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 95,
    "metadata": {},
    "source": [
     "### Saving and Loading Models"
@@ -459,7 +415,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 97,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -469,7 +424,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 99,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -479,7 +433,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 101,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -490,7 +443,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 103,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -499,7 +451,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 106,
    "metadata": {},
    "source": [
     "### Text Generation"
@@ -508,7 +459,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 108,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -522,7 +472,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 109,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -531,7 +480,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 111,
    "metadata": {},
    "source": [
     "### Creating the Classifier DataLoaders"
@@ -540,7 +488,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 113,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -555,7 +502,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 115,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -565,7 +511,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 117,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -575,7 +520,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 119,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -585,7 +529,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 121,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -596,7 +539,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 123,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -605,7 +547,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 124,
    "metadata": {},
    "source": [
     "### Fine-Tuning the Classifier"
@@ -614,7 +555,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 126,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -624,7 +564,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 128,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -635,7 +574,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 130,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -646,7 +584,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 132,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -656,7 +593,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 134,
    "metadata": {},
    "source": [
     "## Disinformation and Language Models"
@@ -664,7 +600,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 142,
    "metadata": {},
    "source": [
     "## Conclusion"
@@ -672,7 +607,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 144,
    "metadata": {},
    "source": [
     "## Questionnaire"
@@ -680,7 +614,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 145,
    "metadata": {},
    "source": [
     "1. What is \"self-supervised learning\"?\n",
@@ -709,7 +642,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 146,
    "metadata": {},
    "source": [
     "### Further Research"
@@ -717,7 +649,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 147,
    "metadata": {},
    "source": [
     "1. See what you can learn about language models and disinformation. What are the best language models today? Take a look at some of their outputs. Do you find them convincing? How could a bad actor best use such a model to create conflict and uncertainty?\n",
@@ -727,7 +658,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 148,
    "metadata": {},
    "outputs": [],
    "source": []
@@ -744,6 +674,5 @@
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2,
- "path_": "10_nlp.ipynb"
+ "nbformat_minor": 2
 }

--- a/clean/11_midlevel_data.ipynb
+++ b/clean/11_midlevel_data.ipynb
@@ -3,6 +3,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 0,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -15,6 +16,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 1,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -25,6 +27,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 3,
    "metadata": {},
    "source": [
     "# Data Munging with fastai's Mid-Level API"
@@ -32,6 +35,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 5,
    "metadata": {},
    "source": [
     "## Going Deeper into fastai's Layered API"
@@ -40,6 +44,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 7,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -51,6 +56,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 9,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -65,6 +71,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 12,
    "metadata": {},
    "source": [
     "### Transforms"
@@ -73,6 +80,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 14,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -83,6 +91,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 16,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -95,6 +104,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 18,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -107,6 +117,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 20,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -116,6 +127,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 22,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -125,6 +137,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 24,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -133,6 +146,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 25,
    "metadata": {},
    "source": [
     "### Writing Your Own Transform"
@@ -141,6 +155,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 27,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -152,6 +167,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 29,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -163,6 +179,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 31,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -175,6 +192,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 33,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -188,6 +206,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 35,
    "metadata": {},
    "source": [
     "### Pipeline"
@@ -196,6 +215,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 37,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -206,6 +226,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 39,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -214,6 +235,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 41,
    "metadata": {},
    "source": [
     "## TfmdLists and Datasets: Transformed Collections"
@@ -221,6 +243,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 43,
    "metadata": {},
    "source": [
     "### TfmdLists"
@@ -229,6 +252,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 45,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -238,6 +262,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 47,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -247,6 +272,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 49,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -256,6 +282,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 51,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -265,6 +292,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 53,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -277,6 +305,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 55,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -286,6 +315,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 57,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -296,6 +326,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 59,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -307,6 +338,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 61,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -316,6 +348,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 63,
    "metadata": {},
    "source": [
     "### Datasets"
@@ -324,6 +357,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 65,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -337,6 +371,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 67,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -350,6 +385,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 69,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -360,6 +396,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 71,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -369,6 +406,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 74,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -382,6 +420,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 76,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -396,6 +435,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 78,
    "metadata": {},
    "source": [
     "## Applying the Mid-Level Data API: SiamesePair"
@@ -404,6 +444,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 80,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -415,6 +456,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 82,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -434,6 +476,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 84,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -445,6 +488,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 86,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -456,6 +500,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 88,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -466,6 +511,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 90,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -476,6 +522,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 92,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -503,6 +550,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 94,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -514,6 +562,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 96,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -524,6 +573,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 98,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -533,6 +583,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 101,
    "metadata": {},
    "source": [
     "## Conclusion"
@@ -540,6 +591,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 103,
    "metadata": {},
    "source": [
     "## Questionnaire"
@@ -547,6 +599,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 104,
    "metadata": {},
    "source": [
     "1. Why do we say that fastai has a \"layered\" API? What does it mean?\n",
@@ -568,6 +621,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 105,
    "metadata": {},
    "source": [
     "### Further Research"
@@ -575,6 +629,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 106,
    "metadata": {},
    "source": [
     "1. Use the mid-level API to prepare the data in `DataLoaders` on your own datasets. Try this with the Pet dataset and the Adult dataset from Chapter 1.\n",
@@ -583,6 +638,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 107,
    "metadata": {},
    "source": [
     "## Understanding fastai's Applications: Wrap Up"
@@ -590,6 +646,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 108,
    "metadata": {},
    "source": [
     "Congratulations—you've completed all of the chapters in this book that cover the key practical parts of training models and using deep learning! You know how to use all of fastai's built-in applications, and how to customize them using the data block API and loss functions. You even know how to create a neural network from scratch, and train it! (And hopefully you now know some of the questions to ask to make sure your creations help improve society too.)\n",
@@ -602,6 +659,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 109,
    "metadata": {},
    "outputs": [],
    "source": []
@@ -612,11 +670,12 @@
    "split_at_heading": true
   },
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "python3",
    "language": "python",
    "name": "python3"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 2,
+ "path_": "11_midlevel_data.ipynb"
 }

--- a/clean/11_midlevel_data.ipynb
+++ b/clean/11_midlevel_data.ipynb
@@ -3,7 +3,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 0,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -16,7 +15,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 1,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -27,7 +25,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 3,
    "metadata": {},
    "source": [
     "# Data Munging with fastai's Mid-Level API"
@@ -35,7 +32,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 5,
    "metadata": {},
    "source": [
     "## Going Deeper into fastai's Layered API"
@@ -44,7 +40,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 7,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -56,7 +51,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 9,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -71,7 +65,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 12,
    "metadata": {},
    "source": [
     "### Transforms"
@@ -80,7 +73,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 14,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -91,7 +83,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 16,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -104,7 +95,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 18,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -117,7 +107,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 20,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -127,7 +116,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 22,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -137,7 +125,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 24,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -146,7 +133,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 25,
    "metadata": {},
    "source": [
     "### Writing Your Own Transform"
@@ -155,7 +141,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 27,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -167,7 +152,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 29,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -179,7 +163,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 31,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -192,7 +175,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 33,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -206,7 +188,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 35,
    "metadata": {},
    "source": [
     "### Pipeline"
@@ -215,7 +196,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 37,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -226,7 +206,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 39,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -235,7 +214,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 41,
    "metadata": {},
    "source": [
     "## TfmdLists and Datasets: Transformed Collections"
@@ -243,7 +221,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 43,
    "metadata": {},
    "source": [
     "### TfmdLists"
@@ -252,7 +229,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 45,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -262,7 +238,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 47,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -272,7 +247,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 49,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -282,7 +256,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 51,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -292,7 +265,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 53,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -305,7 +277,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 55,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -315,7 +286,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 57,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -326,7 +296,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 59,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -338,7 +307,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 61,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -348,7 +316,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 63,
    "metadata": {},
    "source": [
     "### Datasets"
@@ -357,7 +324,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 65,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -371,7 +337,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 67,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -385,7 +350,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 69,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -396,7 +360,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 71,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -406,7 +369,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 74,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -420,7 +382,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 76,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -435,7 +396,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 78,
    "metadata": {},
    "source": [
     "## Applying the Mid-Level Data API: SiamesePair"
@@ -444,7 +404,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 80,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -456,7 +415,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 82,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -476,7 +434,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 84,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -488,7 +445,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 86,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -500,7 +456,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 88,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -511,7 +466,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 90,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -522,7 +476,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 92,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -550,7 +503,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 94,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -562,7 +514,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 96,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -573,7 +524,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 98,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -583,7 +533,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 101,
    "metadata": {},
    "source": [
     "## Conclusion"
@@ -591,7 +540,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 103,
    "metadata": {},
    "source": [
     "## Questionnaire"
@@ -599,7 +547,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 104,
    "metadata": {},
    "source": [
     "1. Why do we say that fastai has a \"layered\" API? What does it mean?\n",
@@ -621,7 +568,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 105,
    "metadata": {},
    "source": [
     "### Further Research"
@@ -629,7 +575,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 106,
    "metadata": {},
    "source": [
     "1. Use the mid-level API to prepare the data in `DataLoaders` on your own datasets. Try this with the Pet dataset and the Adult dataset from Chapter 1.\n",
@@ -638,7 +583,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 107,
    "metadata": {},
    "source": [
     "## Understanding fastai's Applications: Wrap Up"
@@ -646,7 +590,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 108,
    "metadata": {},
    "source": [
     "Congratulations—you've completed all of the chapters in this book that cover the key practical parts of training models and using deep learning! You know how to use all of fastai's built-in applications, and how to customize them using the data block API and loss functions. You even know how to create a neural network from scratch, and train it! (And hopefully you now know some of the questions to ask to make sure your creations help improve society too.)\n",
@@ -659,7 +602,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 109,
    "metadata": {},
    "outputs": [],
    "source": []
@@ -676,6 +618,5 @@
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2,
- "path_": "11_midlevel_data.ipynb"
+ "nbformat_minor": 2
 }

--- a/clean/12_nlp_dive.ipynb
+++ b/clean/12_nlp_dive.ipynb
@@ -3,7 +3,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 0,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -16,7 +15,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 1,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -26,7 +24,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 3,
    "metadata": {},
    "source": [
     "# A Language Model from Scratch"
@@ -34,7 +31,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 5,
    "metadata": {},
    "source": [
     "## The Data"
@@ -43,7 +39,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 9,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -54,7 +49,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 10,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -65,7 +59,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 11,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -75,7 +68,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 13,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -88,7 +80,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 15,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -99,7 +90,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 17,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -110,7 +100,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 19,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -121,7 +110,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 21,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -132,7 +120,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 23,
    "metadata": {},
    "source": [
     "## Our First Language Model from Scratch"
@@ -141,7 +128,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 25,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -151,7 +137,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 27,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -162,7 +147,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 29,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -173,7 +157,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 31,
    "metadata": {},
    "source": [
     "### Our Language Model in PyTorch"
@@ -182,7 +165,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 33,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -204,7 +186,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 41,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -216,7 +197,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 43,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -230,7 +210,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 47,
    "metadata": {},
    "source": [
     "### Our First Recurrent Neural Network"
@@ -239,7 +218,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 49,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -260,7 +238,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 51,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -271,7 +248,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 58,
    "metadata": {},
    "source": [
     "## Improving the RNN"
@@ -279,7 +255,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 60,
    "metadata": {},
    "source": [
     "### Maintaining the State of an RNN"
@@ -288,7 +263,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 62,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -313,7 +287,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 66,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -324,7 +297,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 68,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -338,7 +310,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 70,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -352,7 +323,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 72,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -363,7 +333,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 74,
    "metadata": {},
    "source": [
     "### Creating More Signal"
@@ -372,7 +341,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 78,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -388,7 +356,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 80,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -398,7 +365,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 82,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -424,7 +390,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 84,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -435,7 +400,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 86,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -446,7 +410,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 88,
    "metadata": {},
    "source": [
     "## Multilayer RNNs"
@@ -454,7 +417,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 94,
    "metadata": {},
    "source": [
     "### The Model"
@@ -463,7 +425,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 96,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -485,7 +446,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 97,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -497,7 +457,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 99,
    "metadata": {},
    "source": [
     "### Exploding or Disappearing Activations"
@@ -505,7 +464,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 103,
    "metadata": {},
    "source": [
     "## LSTM"
@@ -513,7 +471,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 105,
    "metadata": {},
    "source": [
     "### Building an LSTM from Scratch"
@@ -522,7 +479,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 108,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -549,7 +505,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 110,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -573,7 +528,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 112,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -583,7 +537,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 113,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -592,7 +545,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 115,
    "metadata": {},
    "source": [
     "### Training a Language Model Using LSTMs"
@@ -601,7 +553,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 117,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -624,7 +575,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 118,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -636,7 +586,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 120,
    "metadata": {},
    "source": [
     "## Regularizing an LSTM"
@@ -644,7 +593,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 122,
    "metadata": {},
    "source": [
     "### Dropout"
@@ -653,7 +601,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 126,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -667,7 +614,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 129,
    "metadata": {},
    "source": [
     "### Activation Regularization and Temporal Activation Regularization"
@@ -675,7 +621,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 132,
    "metadata": {},
    "source": [
     "### Training a Weight-Tied Regularized LSTM"
@@ -684,7 +629,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 134,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -710,7 +654,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 136,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -722,7 +665,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 138,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -733,7 +675,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 140,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -742,7 +683,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 142,
    "metadata": {},
    "source": [
     "## Conclusion"
@@ -750,7 +690,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 144,
    "metadata": {},
    "source": [
     "## Questionnaire"
@@ -758,7 +697,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 145,
    "metadata": {},
    "source": [
     "1. If the dataset for your project is so big and complicated that working with it takes a significant amount of time, what should you do?\n",
@@ -804,7 +742,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 146,
    "metadata": {},
    "source": [
     "### Further Research"
@@ -812,7 +749,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 147,
    "metadata": {},
    "source": [
     "1. In ` LMModel2`, why can `forward` start with `h=0`? Why don't we need to say `h=torch.zeros(...)`?\n",
@@ -824,7 +760,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 148,
    "metadata": {},
    "outputs": [],
    "source": []
@@ -841,6 +776,5 @@
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2,
- "path_": "12_nlp_dive.ipynb"
+ "nbformat_minor": 2
 }

--- a/clean/12_nlp_dive.ipynb
+++ b/clean/12_nlp_dive.ipynb
@@ -3,6 +3,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 0,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -15,6 +16,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 1,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -24,6 +26,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 3,
    "metadata": {},
    "source": [
     "# A Language Model from Scratch"
@@ -31,6 +34,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 5,
    "metadata": {},
    "source": [
     "## The Data"
@@ -39,6 +43,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 9,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -49,6 +54,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 10,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -59,6 +65,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 11,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -68,6 +75,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 13,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -80,6 +88,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 15,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -90,6 +99,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 17,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -100,6 +110,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 19,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -110,6 +121,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 21,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -120,6 +132,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 23,
    "metadata": {},
    "source": [
     "## Our First Language Model from Scratch"
@@ -128,6 +141,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 25,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -137,6 +151,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 27,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -147,6 +162,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 29,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -157,6 +173,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 31,
    "metadata": {},
    "source": [
     "### Our Language Model in PyTorch"
@@ -165,6 +182,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 33,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -186,6 +204,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 41,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -197,6 +216,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 43,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -210,6 +230,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 47,
    "metadata": {},
    "source": [
     "### Our First Recurrent Neural Network"
@@ -218,6 +239,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 49,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -238,6 +260,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 51,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -248,6 +271,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 58,
    "metadata": {},
    "source": [
     "## Improving the RNN"
@@ -255,6 +279,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 60,
    "metadata": {},
    "source": [
     "### Maintaining the State of an RNN"
@@ -263,6 +288,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 62,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -287,6 +313,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 66,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -297,6 +324,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 68,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -310,6 +338,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 70,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -323,6 +352,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 72,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -333,6 +363,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 74,
    "metadata": {},
    "source": [
     "### Creating More Signal"
@@ -341,6 +372,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 78,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -356,6 +388,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 80,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -365,6 +398,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 82,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -390,6 +424,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 84,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -400,6 +435,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 86,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -410,6 +446,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 88,
    "metadata": {},
    "source": [
     "## Multilayer RNNs"
@@ -417,6 +454,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 94,
    "metadata": {},
    "source": [
     "### The Model"
@@ -425,6 +463,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 96,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -446,6 +485,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 97,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -457,6 +497,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 99,
    "metadata": {},
    "source": [
     "### Exploding or Disappearing Activations"
@@ -464,6 +505,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 103,
    "metadata": {},
    "source": [
     "## LSTM"
@@ -471,6 +513,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 105,
    "metadata": {},
    "source": [
     "### Building an LSTM from Scratch"
@@ -479,6 +522,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 108,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -505,6 +549,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 110,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -528,6 +573,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 112,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -537,6 +583,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 113,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -545,6 +592,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 115,
    "metadata": {},
    "source": [
     "### Training a Language Model Using LSTMs"
@@ -553,6 +601,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 117,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -575,6 +624,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 118,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -586,6 +636,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 120,
    "metadata": {},
    "source": [
     "## Regularizing an LSTM"
@@ -593,6 +644,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 122,
    "metadata": {},
    "source": [
     "### Dropout"
@@ -601,6 +653,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 126,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -614,6 +667,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 129,
    "metadata": {},
    "source": [
     "### Activation Regularization and Temporal Activation Regularization"
@@ -621,6 +675,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 132,
    "metadata": {},
    "source": [
     "### Training a Weight-Tied Regularized LSTM"
@@ -629,6 +684,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 134,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -654,6 +710,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 136,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -665,6 +722,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 138,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -675,6 +733,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 140,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -683,6 +742,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 142,
    "metadata": {},
    "source": [
     "## Conclusion"
@@ -690,6 +750,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 144,
    "metadata": {},
    "source": [
     "## Questionnaire"
@@ -697,6 +758,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 145,
    "metadata": {},
    "source": [
     "1. If the dataset for your project is so big and complicated that working with it takes a significant amount of time, what should you do?\n",
@@ -742,6 +804,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 146,
    "metadata": {},
    "source": [
     "### Further Research"
@@ -749,6 +812,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 147,
    "metadata": {},
    "source": [
     "1. In ` LMModel2`, why can `forward` start with `h=0`? Why don't we need to say `h=torch.zeros(...)`?\n",
@@ -760,6 +824,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 148,
    "metadata": {},
    "outputs": [],
    "source": []
@@ -770,11 +835,12 @@
    "split_at_heading": true
   },
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "python3",
    "language": "python",
    "name": "python3"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 2,
+ "path_": "12_nlp_dive.ipynb"
 }

--- a/clean/13_convolutions.ipynb
+++ b/clean/13_convolutions.ipynb
@@ -3,7 +3,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 0,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -16,7 +15,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 1,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -29,7 +27,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 3,
    "metadata": {},
    "source": [
     "# Convolutional Neural Networks"
@@ -37,7 +34,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 5,
    "metadata": {},
    "source": [
     "## The Magic of Convolutions"
@@ -46,7 +42,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 11,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -58,7 +53,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 13,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -68,7 +62,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 14,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -79,7 +72,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 15,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -90,7 +82,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 17,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -101,7 +92,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 18,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -111,7 +101,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 20,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -122,7 +111,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 23,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -132,7 +120,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 25,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -142,7 +129,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 27,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -153,7 +139,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 28,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -162,7 +147,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 30,
    "metadata": {},
    "source": [
     "### Mapping a Convolution Kernel"
@@ -171,7 +155,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 34,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -181,7 +164,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 37,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -194,7 +176,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 39,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -209,7 +190,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 44,
    "metadata": {},
    "source": [
     "### Convolutions in PyTorch"
@@ -218,7 +198,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 46,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -236,7 +215,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 48,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -253,7 +231,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 50,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -263,7 +240,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 52,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -273,7 +249,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 54,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -283,7 +258,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 55,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -294,7 +268,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 57,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -303,7 +276,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 60,
    "metadata": {},
    "source": [
     "### Strides and Padding"
@@ -311,7 +283,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 69,
    "metadata": {},
    "source": [
     "### Understanding the Convolution Equations"
@@ -319,7 +290,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 84,
    "metadata": {},
    "source": [
     "## Our First Convolutional Neural Network"
@@ -327,7 +297,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 86,
    "metadata": {},
    "source": [
     "### Creating the CNN"
@@ -336,7 +305,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 88,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -350,7 +318,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 90,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -360,7 +327,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 92,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -374,7 +340,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 94,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -384,7 +349,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 96,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -397,7 +361,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 101,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -414,7 +377,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 104,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -424,7 +386,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 106,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -434,7 +395,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 108,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -444,7 +404,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 110,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -453,7 +412,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 112,
    "metadata": {},
    "source": [
     "### Understanding Convolution Arithmetic"
@@ -462,7 +420,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 114,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -473,7 +430,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 116,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -483,7 +439,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 118,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -492,7 +447,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 121,
    "metadata": {},
    "source": [
     "### Receptive Fields"
@@ -500,7 +454,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 128,
    "metadata": {},
    "source": [
     "### A Note About Twitter"
@@ -508,7 +461,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 139,
    "metadata": {},
    "source": [
     "## Color Images"
@@ -517,7 +469,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 141,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -528,7 +479,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 142,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -538,7 +488,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 144,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -549,7 +498,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 152,
    "metadata": {},
    "source": [
     "## Improving Training Stability"
@@ -558,7 +506,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 154,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -568,7 +515,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 155,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -579,7 +525,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 156,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -589,7 +534,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 158,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -608,7 +552,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 160,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -617,7 +560,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 162,
    "metadata": {},
    "source": [
     "### A Simple Baseline"
@@ -626,7 +568,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 164,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -639,7 +580,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 166,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -657,7 +597,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 168,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -667,7 +606,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 170,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -681,7 +619,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 171,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -691,7 +628,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 173,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -701,7 +637,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 175,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -710,7 +645,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 177,
    "metadata": {},
    "source": [
     "### Increase Batch Size"
@@ -719,7 +653,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 179,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -729,7 +662,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 180,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -739,7 +671,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 182,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -748,7 +679,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 184,
    "metadata": {},
    "source": [
     "### 1cycle Training"
@@ -757,7 +687,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 186,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -771,7 +700,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 187,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -781,7 +709,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 189,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -791,7 +718,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 191,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -801,7 +727,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 193,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -811,7 +736,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 200,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -820,7 +744,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 202,
    "metadata": {},
    "source": [
     "### Batch Normalization"
@@ -829,7 +752,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 206,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -843,7 +765,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 208,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -853,7 +774,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 210,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -863,7 +783,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 212,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -872,7 +791,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 214,
    "metadata": {},
    "source": [
     "## Conclusions"
@@ -880,7 +798,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 216,
    "metadata": {},
    "source": [
     "## Questionnaire"
@@ -888,7 +805,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 217,
    "metadata": {},
    "source": [
     "1. What is a \"feature\"?\n",
@@ -935,7 +851,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 218,
    "metadata": {},
    "source": [
     "### Further Research"
@@ -943,7 +858,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 219,
    "metadata": {},
    "source": [
     "1. What features other than edge detectors have been used in computer vision (especially before deep learning became popular)?\n",
@@ -954,7 +868,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 220,
    "metadata": {},
    "outputs": [],
    "source": []
@@ -971,6 +884,5 @@
   }
  },
  "nbformat": 4,
- "nbformat_minor": 4,
- "path_": "13_convolutions.ipynb"
+ "nbformat_minor": 4
 }

--- a/clean/13_convolutions.ipynb
+++ b/clean/13_convolutions.ipynb
@@ -3,6 +3,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 0,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -15,6 +16,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 1,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -27,6 +29,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 3,
    "metadata": {},
    "source": [
     "# Convolutional Neural Networks"
@@ -34,6 +37,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 5,
    "metadata": {},
    "source": [
     "## The Magic of Convolutions"
@@ -42,6 +46,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 11,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -53,6 +58,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 13,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -62,6 +68,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 14,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -72,6 +79,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 15,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -82,6 +90,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 17,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -92,6 +101,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 18,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -101,6 +111,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 20,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -111,6 +122,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 23,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -120,6 +132,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 25,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -129,6 +142,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 27,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -139,6 +153,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 28,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -147,6 +162,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 30,
    "metadata": {},
    "source": [
     "### Mapping a Convolution Kernel"
@@ -155,6 +171,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 34,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -164,6 +181,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 37,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -176,6 +194,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 39,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -190,6 +209,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 44,
    "metadata": {},
    "source": [
     "### Convolutions in PyTorch"
@@ -198,6 +218,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 46,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -215,6 +236,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 48,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -231,6 +253,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 50,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -240,6 +263,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 52,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -249,6 +273,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 54,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -258,6 +283,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 55,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -268,6 +294,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 57,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -276,6 +303,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 60,
    "metadata": {},
    "source": [
     "### Strides and Padding"
@@ -283,6 +311,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 69,
    "metadata": {},
    "source": [
     "### Understanding the Convolution Equations"
@@ -290,6 +319,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 84,
    "metadata": {},
    "source": [
     "## Our First Convolutional Neural Network"
@@ -297,6 +327,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 86,
    "metadata": {},
    "source": [
     "### Creating the CNN"
@@ -305,6 +336,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 88,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -318,6 +350,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 90,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -327,6 +360,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 92,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -340,6 +374,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 94,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -349,6 +384,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 96,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -361,6 +397,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 101,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -377,6 +414,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 104,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -386,6 +424,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 106,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -395,6 +434,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 108,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -404,6 +444,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 110,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -412,6 +453,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 112,
    "metadata": {},
    "source": [
     "### Understanding Convolution Arithmetic"
@@ -420,6 +462,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 114,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -430,6 +473,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 116,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -439,6 +483,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 118,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -447,6 +492,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 121,
    "metadata": {},
    "source": [
     "### Receptive Fields"
@@ -454,6 +500,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 128,
    "metadata": {},
    "source": [
     "### A Note About Twitter"
@@ -461,6 +508,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 139,
    "metadata": {},
    "source": [
     "## Color Images"
@@ -469,6 +517,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 141,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -479,6 +528,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 142,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -488,6 +538,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 144,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -498,6 +549,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 152,
    "metadata": {},
    "source": [
     "## Improving Training Stability"
@@ -506,6 +558,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 154,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -515,6 +568,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 155,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -525,6 +579,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 156,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -534,6 +589,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 158,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -552,6 +608,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 160,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -560,6 +617,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 162,
    "metadata": {},
    "source": [
     "### A Simple Baseline"
@@ -568,6 +626,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 164,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -580,6 +639,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 166,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -597,6 +657,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 168,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -606,6 +667,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 170,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -619,6 +681,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 171,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -628,6 +691,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 173,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -637,6 +701,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 175,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -645,6 +710,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 177,
    "metadata": {},
    "source": [
     "### Increase Batch Size"
@@ -653,6 +719,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 179,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -662,6 +729,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 180,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -671,6 +739,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 182,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -679,6 +748,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 184,
    "metadata": {},
    "source": [
     "### 1cycle Training"
@@ -687,6 +757,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 186,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -700,6 +771,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 187,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -709,6 +781,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 189,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -718,6 +791,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 191,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -727,6 +801,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 193,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -736,6 +811,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 200,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -744,6 +820,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 202,
    "metadata": {},
    "source": [
     "### Batch Normalization"
@@ -752,6 +829,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 206,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -765,6 +843,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 208,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -774,6 +853,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 210,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -783,6 +863,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 212,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -791,6 +872,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 214,
    "metadata": {},
    "source": [
     "## Conclusions"
@@ -798,6 +880,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 216,
    "metadata": {},
    "source": [
     "## Questionnaire"
@@ -805,6 +888,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 217,
    "metadata": {},
    "source": [
     "1. What is a \"feature\"?\n",
@@ -851,6 +935,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 218,
    "metadata": {},
    "source": [
     "### Further Research"
@@ -858,6 +943,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 219,
    "metadata": {},
    "source": [
     "1. What features other than edge detectors have been used in computer vision (especially before deep learning became popular)?\n",
@@ -868,6 +954,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 220,
    "metadata": {},
    "outputs": [],
    "source": []
@@ -878,11 +965,12 @@
    "split_at_heading": true
   },
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "python3",
    "language": "python",
    "name": "python3"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 4
+ "nbformat_minor": 4,
+ "path_": "13_convolutions.ipynb"
 }

--- a/clean/14_resnet.ipynb
+++ b/clean/14_resnet.ipynb
@@ -3,7 +3,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 0,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -16,7 +15,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 1,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -26,7 +24,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 3,
    "metadata": {},
    "source": [
     "# ResNets"
@@ -34,7 +31,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 5,
    "metadata": {},
    "source": [
     "## Going Back to Imagenette"
@@ -43,7 +39,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 7,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -61,7 +56,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 8,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -71,7 +65,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 9,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -81,7 +74,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 11,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -91,7 +83,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 13,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -111,7 +102,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 17,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -125,7 +115,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 18,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -135,7 +124,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 20,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -144,7 +132,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 22,
    "metadata": {},
    "source": [
     "## Building a Modern CNN: ResNet"
@@ -152,7 +139,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 24,
    "metadata": {},
    "source": [
     "### Skip Connections"
@@ -161,7 +147,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 31,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -177,7 +162,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 35,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -190,7 +174,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 36,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -207,7 +190,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 38,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -218,7 +200,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 39,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -228,7 +209,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 41,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -239,7 +219,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 42,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -249,7 +228,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 46,
    "metadata": {},
    "source": [
     "### A State-of-the-Art ResNet"
@@ -258,7 +236,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 50,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -272,7 +249,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 51,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -282,7 +258,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 55,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -308,7 +283,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 57,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -318,7 +292,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 59,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -328,7 +301,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 61,
    "metadata": {},
    "source": [
     "### Bottleneck Layers"
@@ -337,7 +309,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 65,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -351,7 +322,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 67,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -361,7 +331,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 69,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -371,7 +340,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 70,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -381,7 +349,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 72,
    "metadata": {},
    "source": [
     "## Conclusion"
@@ -389,7 +356,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 74,
    "metadata": {},
    "source": [
     "## Questionnaire"
@@ -397,7 +363,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 75,
    "metadata": {},
    "source": [
     "1. How did we get to a single vector of activations in the CNNs used for MNIST in previous chapters? Why isn't that suitable for Imagenette?\n",
@@ -426,7 +391,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 76,
    "metadata": {},
    "source": [
     "### Further Research"
@@ -434,7 +398,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 77,
    "metadata": {},
    "source": [
     "1. Try creating a fully convolutional net with adaptive average pooling for MNIST (note that you'll need fewer stride-2 layers). How does it compare to a network without such a pooling layer?\n",
@@ -446,7 +409,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 78,
    "metadata": {},
    "outputs": [],
    "source": []
@@ -463,6 +425,5 @@
   }
  },
  "nbformat": 4,
- "nbformat_minor": 4,
- "path_": "14_resnet.ipynb"
+ "nbformat_minor": 4
 }

--- a/clean/14_resnet.ipynb
+++ b/clean/14_resnet.ipynb
@@ -3,6 +3,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 0,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -15,6 +16,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 1,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -24,6 +26,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 3,
    "metadata": {},
    "source": [
     "# ResNets"
@@ -31,6 +34,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 5,
    "metadata": {},
    "source": [
     "## Going Back to Imagenette"
@@ -39,6 +43,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 7,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -56,6 +61,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 8,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -65,6 +71,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 9,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -74,6 +81,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 11,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -83,6 +91,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 13,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -102,6 +111,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 17,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -115,6 +125,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 18,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -124,6 +135,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 20,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -132,6 +144,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 22,
    "metadata": {},
    "source": [
     "## Building a Modern CNN: ResNet"
@@ -139,6 +152,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 24,
    "metadata": {},
    "source": [
     "### Skip Connections"
@@ -147,6 +161,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 31,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -162,6 +177,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 35,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -174,6 +190,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 36,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -190,6 +207,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 38,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -200,6 +218,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 39,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -209,6 +228,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 41,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -219,6 +239,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 42,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -228,6 +249,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 46,
    "metadata": {},
    "source": [
     "### A State-of-the-Art ResNet"
@@ -236,6 +258,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 50,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -249,6 +272,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 51,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -258,6 +282,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 55,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -283,6 +308,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 57,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -292,6 +318,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 59,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -301,6 +328,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 61,
    "metadata": {},
    "source": [
     "### Bottleneck Layers"
@@ -309,6 +337,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 65,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -322,6 +351,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 67,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -331,6 +361,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 69,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -340,6 +371,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 70,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -349,6 +381,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 72,
    "metadata": {},
    "source": [
     "## Conclusion"
@@ -356,6 +389,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 74,
    "metadata": {},
    "source": [
     "## Questionnaire"
@@ -363,6 +397,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 75,
    "metadata": {},
    "source": [
     "1. How did we get to a single vector of activations in the CNNs used for MNIST in previous chapters? Why isn't that suitable for Imagenette?\n",
@@ -391,6 +426,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 76,
    "metadata": {},
    "source": [
     "### Further Research"
@@ -398,6 +434,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 77,
    "metadata": {},
    "source": [
     "1. Try creating a fully convolutional net with adaptive average pooling for MNIST (note that you'll need fewer stride-2 layers). How does it compare to a network without such a pooling layer?\n",
@@ -409,6 +446,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 78,
    "metadata": {},
    "outputs": [],
    "source": []
@@ -419,11 +457,12 @@
    "split_at_heading": true
   },
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "python3",
    "language": "python",
    "name": "python3"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 4
+ "nbformat_minor": 4,
+ "path_": "14_resnet.ipynb"
 }

--- a/clean/15_arch_details.ipynb
+++ b/clean/15_arch_details.ipynb
@@ -3,6 +3,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 0,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -15,6 +16,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 1,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -24,6 +26,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 3,
    "metadata": {},
    "source": [
     "# Application Architectures Deep Dive"
@@ -31,6 +34,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 5,
    "metadata": {},
    "source": [
     "## Computer Vision"
@@ -38,6 +42,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 7,
    "metadata": {},
    "source": [
     "### vision_learner"
@@ -46,6 +51,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 9,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -55,6 +61,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 12,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -63,6 +70,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 17,
    "metadata": {},
    "source": [
     "### unet_learner"
@@ -70,6 +78,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 23,
    "metadata": {},
    "source": [
     "### A Siamese Network"
@@ -78,6 +87,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 24,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -129,6 +139,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 26,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -144,6 +155,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 28,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -153,6 +165,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 30,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -162,6 +175,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 32,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -171,6 +185,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 34,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -181,6 +196,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 36,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -191,6 +207,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 38,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -202,6 +219,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 40,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -211,6 +229,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 42,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -220,6 +239,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 45,
    "metadata": {},
    "source": [
     "## Natural Language Processing"
@@ -227,6 +247,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 49,
    "metadata": {},
    "source": [
     "## Tabular"
@@ -234,6 +255,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 52,
    "metadata": {},
    "source": [
     "## Wrapping Up Architectures"
@@ -241,6 +263,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 56,
    "metadata": {},
    "source": [
     "## Questionnaire"
@@ -248,6 +271,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 57,
    "metadata": {},
    "source": [
     "1. What is the \"head\" of a neural net?\n",
@@ -272,6 +296,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 58,
    "metadata": {},
    "source": [
     "### Further Research"
@@ -279,6 +304,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 59,
    "metadata": {},
    "source": [
     "1. Write your own custom head and try training the pet recognizer with it. See if you can get a better result than fastai's default.\n",
@@ -291,6 +317,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 60,
    "metadata": {},
    "outputs": [],
    "source": []
@@ -301,11 +328,12 @@
    "split_at_heading": true
   },
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "python3",
    "language": "python",
    "name": "python3"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 2,
+ "path_": "15_arch_details.ipynb"
 }

--- a/clean/15_arch_details.ipynb
+++ b/clean/15_arch_details.ipynb
@@ -3,7 +3,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 0,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -16,7 +15,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 1,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -26,7 +24,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 3,
    "metadata": {},
    "source": [
     "# Application Architectures Deep Dive"
@@ -34,7 +31,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 5,
    "metadata": {},
    "source": [
     "## Computer Vision"
@@ -42,7 +38,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 7,
    "metadata": {},
    "source": [
     "### vision_learner"
@@ -51,7 +46,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 9,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -61,7 +55,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 12,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -70,7 +63,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 17,
    "metadata": {},
    "source": [
     "### unet_learner"
@@ -78,7 +70,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 23,
    "metadata": {},
    "source": [
     "### A Siamese Network"
@@ -87,7 +78,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 24,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -139,7 +129,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 26,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -155,7 +144,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 28,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -165,7 +153,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 30,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -175,7 +162,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 32,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -185,7 +171,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 34,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -196,7 +181,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 36,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -207,7 +191,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 38,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -219,7 +202,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 40,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -229,7 +211,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 42,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -239,7 +220,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 45,
    "metadata": {},
    "source": [
     "## Natural Language Processing"
@@ -247,7 +227,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 49,
    "metadata": {},
    "source": [
     "## Tabular"
@@ -255,7 +234,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 52,
    "metadata": {},
    "source": [
     "## Wrapping Up Architectures"
@@ -263,7 +241,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 56,
    "metadata": {},
    "source": [
     "## Questionnaire"
@@ -271,7 +248,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 57,
    "metadata": {},
    "source": [
     "1. What is the \"head\" of a neural net?\n",
@@ -296,7 +272,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 58,
    "metadata": {},
    "source": [
     "### Further Research"
@@ -304,7 +279,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 59,
    "metadata": {},
    "source": [
     "1. Write your own custom head and try training the pet recognizer with it. See if you can get a better result than fastai's default.\n",
@@ -317,7 +291,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 60,
    "metadata": {},
    "outputs": [],
    "source": []
@@ -334,6 +307,5 @@
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2,
- "path_": "15_arch_details.ipynb"
+ "nbformat_minor": 2
 }

--- a/clean/16_accel_sgd.ipynb
+++ b/clean/16_accel_sgd.ipynb
@@ -3,7 +3,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 0,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -16,7 +15,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 1,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -26,7 +24,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 3,
    "metadata": {},
    "source": [
     "# The Training Process"
@@ -34,7 +31,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 5,
    "metadata": {},
    "source": [
     "## Establishing a Baseline"
@@ -43,7 +39,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 7,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -61,7 +56,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 8,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -71,7 +65,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 10,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -83,7 +76,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 12,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -94,7 +86,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 14,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -104,7 +95,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 16,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -114,7 +104,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 18,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -123,7 +112,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 20,
    "metadata": {},
    "source": [
     "## A Generic Optimizer"
@@ -132,7 +120,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 23,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -142,7 +129,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 25,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -152,7 +138,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 27,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -162,7 +147,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 29,
    "metadata": {},
    "source": [
     "## Momentum"
@@ -171,7 +155,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 31,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -191,7 +174,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 33,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -215,7 +197,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 36,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -227,7 +208,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 38,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -237,7 +217,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 39,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -247,7 +226,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 41,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -258,7 +236,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 42,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -267,7 +244,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 44,
    "metadata": {},
    "source": [
     "## RMSProp"
@@ -276,7 +252,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 47,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -288,7 +263,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 49,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -303,7 +277,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 51,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -313,7 +286,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 53,
    "metadata": {},
    "source": [
     "## Adam"
@@ -321,7 +293,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 55,
    "metadata": {},
    "source": [
     "## Decoupled Weight Decay"
@@ -329,7 +300,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 57,
    "metadata": {},
    "source": [
     "## Callbacks"
@@ -337,7 +307,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 66,
    "metadata": {},
    "source": [
     "### Creating a Callback"
@@ -346,7 +315,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 69,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -358,7 +326,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 71,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -382,7 +349,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 76,
    "metadata": {},
    "source": [
     "### Callback Ordering and Exceptions"
@@ -391,7 +357,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 78,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -404,7 +369,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 82,
    "metadata": {},
    "source": [
     "## Conclusion"
@@ -412,7 +376,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 84,
    "metadata": {},
    "source": [
     "## Questionnaire"
@@ -420,7 +383,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 85,
    "metadata": {},
    "source": [
     "1. What is the equation for a step of SGD, in math or code (as you prefer)?\n",
@@ -454,7 +416,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 86,
    "metadata": {},
    "source": [
     "### Further Research"
@@ -462,7 +423,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 87,
    "metadata": {},
    "source": [
     "1. Look up the \"Rectified Adam\" paper, implement it using the general optimizer framework, and try it out. Search for other recent optimizers that work well in practice, and pick one to implement.\n",
@@ -473,7 +433,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 88,
    "metadata": {},
    "source": [
     "## Foundations of Deep Learning: Wrap up"
@@ -481,7 +440,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 89,
    "metadata": {},
    "source": [
     "Congratulations, you have made it to the end of the \"foundations of deep learning\" section of the book! You now understand how all of fastai's applications and most important architectures are built, and the recommended ways to train them—and you have all the information you need to build these from scratch. While you probably won't need to create your own training loop, or batchnorm layer, for instance, knowing what is going on behind the scenes is very helpful for debugging, profiling, and deploying your solutions.\n",
@@ -494,7 +452,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 90,
    "metadata": {},
    "outputs": [],
    "source": []
@@ -511,6 +468,5 @@
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2,
- "path_": "16_accel_sgd.ipynb"
+ "nbformat_minor": 2
 }

--- a/clean/16_accel_sgd.ipynb
+++ b/clean/16_accel_sgd.ipynb
@@ -3,6 +3,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 0,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -15,6 +16,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 1,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -24,6 +26,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 3,
    "metadata": {},
    "source": [
     "# The Training Process"
@@ -31,6 +34,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 5,
    "metadata": {},
    "source": [
     "## Establishing a Baseline"
@@ -39,6 +43,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 7,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -56,6 +61,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 8,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -65,6 +71,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 10,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -76,6 +83,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 12,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -86,6 +94,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 14,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -95,6 +104,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 16,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -104,6 +114,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 18,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -112,6 +123,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 20,
    "metadata": {},
    "source": [
     "## A Generic Optimizer"
@@ -120,6 +132,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 23,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -129,6 +142,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 25,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -138,6 +152,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 27,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -147,6 +162,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 29,
    "metadata": {},
    "source": [
     "## Momentum"
@@ -155,6 +171,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 31,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -174,6 +191,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 33,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -197,6 +215,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 36,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -208,6 +227,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 38,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -217,6 +237,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 39,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -226,6 +247,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 41,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -236,6 +258,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 42,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -244,6 +267,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 44,
    "metadata": {},
    "source": [
     "## RMSProp"
@@ -252,6 +276,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 47,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -263,6 +288,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 49,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -277,6 +303,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 51,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -286,6 +313,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 53,
    "metadata": {},
    "source": [
     "## Adam"
@@ -293,6 +321,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 55,
    "metadata": {},
    "source": [
     "## Decoupled Weight Decay"
@@ -300,6 +329,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 57,
    "metadata": {},
    "source": [
     "## Callbacks"
@@ -307,6 +337,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 66,
    "metadata": {},
    "source": [
     "### Creating a Callback"
@@ -315,6 +346,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 69,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -326,6 +358,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 71,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -349,6 +382,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 76,
    "metadata": {},
    "source": [
     "### Callback Ordering and Exceptions"
@@ -357,6 +391,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 78,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -369,6 +404,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 82,
    "metadata": {},
    "source": [
     "## Conclusion"
@@ -376,6 +412,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 84,
    "metadata": {},
    "source": [
     "## Questionnaire"
@@ -383,6 +420,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 85,
    "metadata": {},
    "source": [
     "1. What is the equation for a step of SGD, in math or code (as you prefer)?\n",
@@ -416,6 +454,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 86,
    "metadata": {},
    "source": [
     "### Further Research"
@@ -423,6 +462,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 87,
    "metadata": {},
    "source": [
     "1. Look up the \"Rectified Adam\" paper, implement it using the general optimizer framework, and try it out. Search for other recent optimizers that work well in practice, and pick one to implement.\n",
@@ -433,6 +473,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 88,
    "metadata": {},
    "source": [
     "## Foundations of Deep Learning: Wrap up"
@@ -440,6 +481,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 89,
    "metadata": {},
    "source": [
     "Congratulations, you have made it to the end of the \"foundations of deep learning\" section of the book! You now understand how all of fastai's applications and most important architectures are built, and the recommended ways to train them—and you have all the information you need to build these from scratch. While you probably won't need to create your own training loop, or batchnorm layer, for instance, knowing what is going on behind the scenes is very helpful for debugging, profiling, and deploying your solutions.\n",
@@ -452,6 +494,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 90,
    "metadata": {},
    "outputs": [],
    "source": []
@@ -462,11 +505,12 @@
    "split_at_heading": true
   },
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "python3",
    "language": "python",
    "name": "python3"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 2,
+ "path_": "16_accel_sgd.ipynb"
 }

--- a/clean/17_foundations.ipynb
+++ b/clean/17_foundations.ipynb
@@ -3,7 +3,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 0,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -15,7 +14,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 2,
    "metadata": {},
    "source": [
     "# A Neural Net from the Foundations"
@@ -23,7 +21,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 4,
    "metadata": {},
    "source": [
     "## Building a Neural Net Layer from Scratch"
@@ -31,7 +28,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 6,
    "metadata": {},
    "source": [
     "### Modeling a Neuron"
@@ -39,7 +35,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 9,
    "metadata": {},
    "source": [
     "### Matrix Multiplication from Scratch"
@@ -48,7 +43,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 11,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -59,7 +53,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 13,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -77,7 +70,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 15,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -88,7 +80,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 17,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -98,7 +89,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 19,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -107,7 +97,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 21,
    "metadata": {},
    "source": [
     "### Elementwise Arithmetic"
@@ -116,7 +105,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 23,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -128,7 +116,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 25,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -138,7 +125,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 27,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -148,7 +134,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 29,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -158,7 +143,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 31,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -169,7 +153,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 33,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -180,7 +163,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 35,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -197,7 +179,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 36,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -206,7 +187,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 38,
    "metadata": {},
    "source": [
     "### Broadcasting"
@@ -214,7 +194,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 40,
    "metadata": {},
    "source": [
     "#### Broadcasting with a scalar"
@@ -223,7 +202,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 42,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -234,7 +212,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 44,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -244,7 +221,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 46,
    "metadata": {},
    "source": [
     "#### Broadcasting a vector to a matrix"
@@ -253,7 +229,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 48,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -265,7 +240,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 49,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -275,7 +249,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 51,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -285,7 +258,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 53,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -296,7 +268,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 55,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -306,7 +277,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 57,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -316,7 +286,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 59,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -328,7 +297,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 61,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -340,7 +308,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 63,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -353,7 +320,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 65,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -363,7 +329,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 67,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -374,7 +339,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 69,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -384,7 +348,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 71,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -395,7 +358,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 73,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -405,7 +367,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 75,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -415,7 +376,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 77,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -433,7 +393,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 78,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -442,7 +401,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 80,
    "metadata": {},
    "source": [
     "#### Broadcasting rules"
@@ -450,7 +408,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 83,
    "metadata": {},
    "source": [
     "### Einstein Summation"
@@ -459,7 +416,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 85,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -469,7 +425,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 87,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -478,7 +433,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 90,
    "metadata": {},
    "source": [
     "## The Forward and Backward Passes"
@@ -486,7 +440,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 92,
    "metadata": {},
    "source": [
     "### Defining and Initializing a Layer"
@@ -495,7 +448,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 94,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -505,7 +457,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 96,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -516,7 +467,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 98,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -529,7 +479,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 100,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -540,7 +489,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 102,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -550,7 +498,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 104,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -562,7 +509,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 106,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -574,7 +520,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 108,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -586,7 +531,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 110,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -596,7 +540,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 112,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -607,7 +550,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 114,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -621,7 +563,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 116,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -632,7 +573,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 118,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -642,7 +582,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 120,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -653,7 +592,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 122,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -665,7 +603,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 124,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -677,7 +614,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 126,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -688,7 +624,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 127,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -701,7 +636,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 129,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -713,7 +647,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 131,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -727,7 +660,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 133,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -738,7 +670,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 135,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -748,7 +679,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 137,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -757,7 +687,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 139,
    "metadata": {},
    "source": [
     "### Gradients and the Backward Pass"
@@ -766,7 +695,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 143,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -778,7 +706,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 145,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -790,7 +717,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 147,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -803,7 +729,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 149,
    "metadata": {},
    "source": [
     "### Sidebar: SymPy"
@@ -812,7 +737,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 153,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -823,7 +747,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 155,
    "metadata": {},
    "source": [
     "### End sidebar"
@@ -832,7 +755,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 157,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -853,7 +775,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 160,
    "metadata": {},
    "source": [
     "### Refactoring the Model"
@@ -862,7 +783,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 162,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -878,7 +798,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 164,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -899,7 +818,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 165,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -918,7 +836,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 167,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -939,7 +856,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 169,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -949,7 +865,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 171,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -959,7 +874,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 173,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -968,7 +882,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 174,
    "metadata": {},
    "source": [
     "### Going to PyTorch"
@@ -977,7 +890,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 176,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -995,7 +907,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 178,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1007,7 +918,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 179,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1025,7 +935,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 180,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1038,7 +947,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 182,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1060,7 +968,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 184,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1078,7 +985,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 186,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1090,7 +996,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 188,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1107,7 +1012,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 190,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1122,7 +1026,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 192,
    "metadata": {},
    "source": [
     "## Conclusion"
@@ -1130,7 +1033,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 194,
    "metadata": {},
    "source": [
     "## Questionnaire"
@@ -1138,7 +1040,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 195,
    "metadata": {},
    "source": [
     "1. Write the Python code to implement a single neuron.\n",
@@ -1185,7 +1086,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 196,
    "metadata": {},
    "source": [
     "### Further Research"
@@ -1193,7 +1093,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 197,
    "metadata": {},
    "source": [
     "1. Implement ReLU as a `torch.autograd.Function` and train a model with it.\n",
@@ -1205,7 +1104,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 198,
    "metadata": {},
    "outputs": [],
    "source": []
@@ -1222,6 +1120,5 @@
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2,
- "path_": "17_foundations.ipynb"
+ "nbformat_minor": 2
 }

--- a/clean/17_foundations.ipynb
+++ b/clean/17_foundations.ipynb
@@ -3,6 +3,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 0,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -14,6 +15,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 2,
    "metadata": {},
    "source": [
     "# A Neural Net from the Foundations"
@@ -21,6 +23,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 4,
    "metadata": {},
    "source": [
     "## Building a Neural Net Layer from Scratch"
@@ -28,6 +31,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 6,
    "metadata": {},
    "source": [
     "### Modeling a Neuron"
@@ -35,6 +39,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 9,
    "metadata": {},
    "source": [
     "### Matrix Multiplication from Scratch"
@@ -43,6 +48,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 11,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -53,6 +59,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 13,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -70,6 +77,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 15,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -80,6 +88,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 17,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -89,6 +98,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 19,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -97,6 +107,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 21,
    "metadata": {},
    "source": [
     "### Elementwise Arithmetic"
@@ -105,6 +116,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 23,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -116,6 +128,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 25,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -125,6 +138,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 27,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -134,6 +148,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 29,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -143,6 +158,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 31,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -153,6 +169,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 33,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -163,6 +180,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 35,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -179,6 +197,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 36,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -187,6 +206,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 38,
    "metadata": {},
    "source": [
     "### Broadcasting"
@@ -194,6 +214,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 40,
    "metadata": {},
    "source": [
     "#### Broadcasting with a scalar"
@@ -202,6 +223,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 42,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -212,6 +234,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 44,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -221,6 +244,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 46,
    "metadata": {},
    "source": [
     "#### Broadcasting a vector to a matrix"
@@ -229,6 +253,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 48,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -240,6 +265,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 49,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -249,6 +275,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 51,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -258,6 +285,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 53,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -268,6 +296,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 55,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -277,6 +306,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 57,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -286,6 +316,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 59,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -297,6 +328,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 61,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -308,6 +340,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 63,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -320,6 +353,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 65,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -329,6 +363,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 67,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -339,6 +374,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 69,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -348,6 +384,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 71,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -358,6 +395,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 73,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -367,6 +405,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 75,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -376,6 +415,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 77,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -393,6 +433,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 78,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -401,6 +442,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 80,
    "metadata": {},
    "source": [
     "#### Broadcasting rules"
@@ -408,6 +450,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 83,
    "metadata": {},
    "source": [
     "### Einstein Summation"
@@ -416,6 +459,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 85,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -425,6 +469,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 87,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -433,6 +478,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 90,
    "metadata": {},
    "source": [
     "## The Forward and Backward Passes"
@@ -440,6 +486,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 92,
    "metadata": {},
    "source": [
     "### Defining and Initializing a Layer"
@@ -448,6 +495,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 94,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -457,6 +505,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 96,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -467,6 +516,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 98,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -479,6 +529,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 100,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -489,6 +540,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 102,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -498,6 +550,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 104,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -509,6 +562,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 106,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -520,6 +574,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 108,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -531,6 +586,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 110,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -540,6 +596,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 112,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -550,6 +607,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 114,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -563,6 +621,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 116,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -573,6 +632,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 118,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -582,6 +642,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 120,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -592,6 +653,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 122,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -603,6 +665,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 124,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -614,6 +677,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 126,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -624,6 +688,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 127,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -636,6 +701,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 129,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -647,6 +713,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 131,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -660,6 +727,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 133,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -670,6 +738,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 135,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -679,6 +748,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 137,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -687,6 +757,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 139,
    "metadata": {},
    "source": [
     "### Gradients and the Backward Pass"
@@ -695,6 +766,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 143,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -706,6 +778,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 145,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -717,6 +790,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 147,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -729,6 +803,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 149,
    "metadata": {},
    "source": [
     "### Sidebar: SymPy"
@@ -737,6 +812,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 153,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -747,6 +823,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 155,
    "metadata": {},
    "source": [
     "### End sidebar"
@@ -755,6 +832,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 157,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -775,6 +853,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 160,
    "metadata": {},
    "source": [
     "### Refactoring the Model"
@@ -783,6 +862,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 162,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -798,6 +878,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 164,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -818,6 +899,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 165,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -836,6 +918,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 167,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -856,6 +939,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 169,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -865,6 +949,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 171,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -874,6 +959,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 173,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -882,6 +968,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 174,
    "metadata": {},
    "source": [
     "### Going to PyTorch"
@@ -890,6 +977,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 176,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -907,6 +995,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 178,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -918,6 +1007,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 179,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -935,6 +1025,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 180,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -947,6 +1038,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 182,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -968,6 +1060,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 184,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -985,6 +1078,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 186,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -996,6 +1090,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 188,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1012,6 +1107,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 190,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1026,6 +1122,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 192,
    "metadata": {},
    "source": [
     "## Conclusion"
@@ -1033,6 +1130,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 194,
    "metadata": {},
    "source": [
     "## Questionnaire"
@@ -1040,6 +1138,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 195,
    "metadata": {},
    "source": [
     "1. Write the Python code to implement a single neuron.\n",
@@ -1086,6 +1185,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 196,
    "metadata": {},
    "source": [
     "### Further Research"
@@ -1093,6 +1193,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 197,
    "metadata": {},
    "source": [
     "1. Implement ReLU as a `torch.autograd.Function` and train a model with it.\n",
@@ -1104,6 +1205,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 198,
    "metadata": {},
    "outputs": [],
    "source": []
@@ -1114,11 +1216,12 @@
    "split_at_heading": true
   },
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "python3",
    "language": "python",
    "name": "python3"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 2,
+ "path_": "17_foundations.ipynb"
 }

--- a/clean/18_CAM.ipynb
+++ b/clean/18_CAM.ipynb
@@ -3,6 +3,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 0,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -15,6 +16,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 1,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -24,6 +26,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 3,
    "metadata": {},
    "source": [
     "# CNN Interpretation with CAM"
@@ -31,6 +34,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 5,
    "metadata": {},
    "source": [
     "## CAM and Hooks"
@@ -39,6 +43,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 7,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -54,6 +59,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 9,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -64,6 +70,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 11,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -74,6 +81,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 13,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -84,6 +92,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 15,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -93,6 +102,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 17,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -102,6 +112,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 19,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -111,6 +122,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 21,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -120,6 +132,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 24,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -129,6 +142,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 25,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -139,6 +153,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 27,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -152,6 +167,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 29,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -161,6 +177,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 31,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -175,6 +192,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 33,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -185,6 +203,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 36,
    "metadata": {},
    "source": [
     "## Gradient CAM"
@@ -193,6 +212,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 38,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -207,6 +227,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 40,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -222,6 +243,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 42,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -232,6 +254,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 43,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -244,6 +267,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 45,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -258,6 +282,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 46,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -268,6 +293,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 48,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -279,6 +305,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 49,
    "metadata": {},
    "source": [
     "## Conclusion"
@@ -286,6 +313,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 51,
    "metadata": {},
    "source": [
     "## Questionnaire"
@@ -293,6 +321,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 52,
    "metadata": {},
    "source": [
     "1. What is a \"hook\" in PyTorch?\n",
@@ -312,6 +341,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 53,
    "metadata": {},
    "source": [
     "### Further Research"
@@ -319,6 +349,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 54,
    "metadata": {},
    "source": [
     "1. Try removing `keepdim` and see what happens. Look up this parameter in the PyTorch docs. Why do we need it in this notebook?\n",
@@ -328,6 +359,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 55,
    "metadata": {},
    "outputs": [],
    "source": []
@@ -338,11 +370,12 @@
    "split_at_heading": true
   },
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "python3",
    "language": "python",
    "name": "python3"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 2,
+ "path_": "18_CAM.ipynb"
 }

--- a/clean/18_CAM.ipynb
+++ b/clean/18_CAM.ipynb
@@ -3,7 +3,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 0,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -16,7 +15,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 1,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -26,7 +24,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 3,
    "metadata": {},
    "source": [
     "# CNN Interpretation with CAM"
@@ -34,7 +31,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 5,
    "metadata": {},
    "source": [
     "## CAM and Hooks"
@@ -43,7 +39,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 7,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -59,7 +54,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 9,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -70,7 +64,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 11,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -81,7 +74,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 13,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -92,7 +84,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 15,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -102,7 +93,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 17,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -112,7 +102,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 19,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -122,7 +111,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 21,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -132,7 +120,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 24,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -142,7 +129,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 25,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -153,7 +139,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 27,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -167,7 +152,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 29,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -177,7 +161,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 31,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -192,7 +175,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 33,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -203,7 +185,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 36,
    "metadata": {},
    "source": [
     "## Gradient CAM"
@@ -212,7 +193,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 38,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -227,7 +207,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 40,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -243,7 +222,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 42,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -254,7 +232,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 43,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -267,7 +244,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 45,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -282,7 +258,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 46,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -293,7 +268,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 48,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -305,7 +279,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 49,
    "metadata": {},
    "source": [
     "## Conclusion"
@@ -313,7 +286,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 51,
    "metadata": {},
    "source": [
     "## Questionnaire"
@@ -321,7 +293,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 52,
    "metadata": {},
    "source": [
     "1. What is a \"hook\" in PyTorch?\n",
@@ -341,7 +312,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 53,
    "metadata": {},
    "source": [
     "### Further Research"
@@ -349,7 +319,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 54,
    "metadata": {},
    "source": [
     "1. Try removing `keepdim` and see what happens. Look up this parameter in the PyTorch docs. Why do we need it in this notebook?\n",
@@ -359,7 +328,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 55,
    "metadata": {},
    "outputs": [],
    "source": []
@@ -376,6 +344,5 @@
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2,
- "path_": "18_CAM.ipynb"
+ "nbformat_minor": 2
 }

--- a/clean/19_learner.ipynb
+++ b/clean/19_learner.ipynb
@@ -3,7 +3,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 0,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -16,7 +15,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 1,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -26,7 +24,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 2,
    "metadata": {},
    "source": [
     "# A fastai Learner from Scratch"
@@ -34,7 +31,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 5,
    "metadata": {},
    "source": [
     "## Data"
@@ -43,7 +39,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 7,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -53,7 +48,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 9,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -64,7 +58,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 11,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -76,7 +69,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 13,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -87,7 +79,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 14,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -98,7 +89,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 16,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -108,7 +98,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 18,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -117,7 +106,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 20,
    "metadata": {},
    "source": [
     "### Dataset"
@@ -126,7 +114,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 22,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -142,7 +129,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 24,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -154,7 +140,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 26,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -166,7 +151,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 27,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -176,7 +160,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 29,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -188,7 +171,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 31,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -199,7 +181,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 33,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -220,7 +201,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 35,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -234,7 +214,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 37,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -245,7 +224,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 39,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -260,7 +238,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 41,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -271,7 +248,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 42,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -281,7 +257,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 45,
    "metadata": {},
    "source": [
     "## Module and Parameter"
@@ -290,7 +265,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 47,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -302,7 +276,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 49,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -312,7 +285,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 51,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -350,7 +322,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 53,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -372,7 +343,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 55,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -383,7 +353,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 57,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -395,7 +364,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 59,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -412,7 +380,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 61,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -424,7 +391,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 63,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -437,7 +403,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 65,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -448,7 +413,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 67,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -458,7 +422,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 69,
    "metadata": {},
    "source": [
     "### Simple CNN"
@@ -467,7 +430,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 71,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -485,7 +447,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 75,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -496,7 +457,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 77,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -514,7 +474,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 79,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -525,7 +484,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 81,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -538,7 +496,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 83,
    "metadata": {},
    "source": [
     "## Loss"
@@ -547,7 +504,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 85,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -557,7 +513,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 87,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -569,7 +524,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 89,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -580,7 +534,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 91,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -591,7 +544,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 93,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -603,7 +555,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 95,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -617,7 +568,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 97,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -627,7 +577,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 99,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -637,7 +586,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 101,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -646,7 +594,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 103,
    "metadata": {},
    "source": [
     "## Learner"
@@ -655,7 +602,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 105,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -670,7 +616,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 107,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -683,7 +628,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 109,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -727,7 +671,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 111,
    "metadata": {},
    "source": [
     "### Callbacks"
@@ -736,7 +679,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 113,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -746,7 +688,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 116,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -761,7 +702,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 118,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -785,7 +725,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 120,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -796,7 +735,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 122,
    "metadata": {},
    "source": [
     "### Scheduling the Learning Rate"
@@ -805,7 +743,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 124,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -828,7 +765,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 126,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -840,7 +776,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 128,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -851,7 +786,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 130,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -879,7 +813,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 132,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -890,7 +823,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 134,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -900,7 +832,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 136,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -909,7 +840,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 137,
    "metadata": {},
    "source": [
     "## Conclusion"
@@ -917,7 +847,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 139,
    "metadata": {},
    "source": [
     "## Questionnaire"
@@ -925,7 +854,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 140,
    "metadata": {},
    "source": [
     "> tip: Experiments: For the questions here that ask you to explain what some function or class is, you should also complete your own code experiments."
@@ -933,7 +861,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 141,
    "metadata": {},
    "source": [
     "1. What is `glob`?\n",
@@ -974,7 +901,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 142,
    "metadata": {},
    "source": [
     "### Further Research"
@@ -982,7 +908,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 143,
    "metadata": {},
    "source": [
     "1. Write `resnet18` from scratch (refer to <<chapter_resnet>> as needed), and train it with the `Learner` in this chapter.\n",
@@ -999,7 +924,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 144,
    "metadata": {},
    "outputs": [],
    "source": []
@@ -1016,6 +940,5 @@
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2,
- "path_": "19_learner.ipynb"
+ "nbformat_minor": 2
 }

--- a/clean/19_learner.ipynb
+++ b/clean/19_learner.ipynb
@@ -3,6 +3,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 0,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -15,6 +16,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 1,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -24,6 +26,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 2,
    "metadata": {},
    "source": [
     "# A fastai Learner from Scratch"
@@ -31,6 +34,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 5,
    "metadata": {},
    "source": [
     "## Data"
@@ -39,6 +43,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 7,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -48,6 +53,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 9,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -58,6 +64,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 11,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -69,6 +76,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 13,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -79,6 +87,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 14,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -89,6 +98,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 16,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -98,6 +108,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 18,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -106,6 +117,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 20,
    "metadata": {},
    "source": [
     "### Dataset"
@@ -114,6 +126,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 22,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -129,6 +142,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 24,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -140,6 +154,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 26,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -151,6 +166,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 27,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -160,6 +176,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 29,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -171,6 +188,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 31,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -181,6 +199,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 33,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -201,6 +220,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 35,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -214,6 +234,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 37,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -224,6 +245,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 39,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -238,6 +260,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 41,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -248,6 +271,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 42,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -257,6 +281,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 45,
    "metadata": {},
    "source": [
     "## Module and Parameter"
@@ -265,6 +290,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 47,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -276,6 +302,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 49,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -285,6 +312,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 51,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -322,6 +350,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 53,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -343,6 +372,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 55,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -353,6 +383,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 57,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -364,6 +395,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 59,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -380,6 +412,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 61,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -391,6 +424,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 63,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -403,6 +437,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 65,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -413,6 +448,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 67,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -422,6 +458,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 69,
    "metadata": {},
    "source": [
     "### Simple CNN"
@@ -430,6 +467,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 71,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -447,6 +485,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 75,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -457,6 +496,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 77,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -474,6 +514,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 79,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -484,6 +525,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 81,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -496,6 +538,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 83,
    "metadata": {},
    "source": [
     "## Loss"
@@ -504,6 +547,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 85,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -513,6 +557,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 87,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -524,6 +569,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 89,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -534,6 +580,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 91,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -544,6 +591,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 93,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -555,6 +603,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 95,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -568,6 +617,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 97,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -577,6 +627,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 99,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -586,6 +637,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 101,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -594,6 +646,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 103,
    "metadata": {},
    "source": [
     "## Learner"
@@ -602,6 +655,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 105,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -616,6 +670,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 107,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -628,6 +683,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 109,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -671,6 +727,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 111,
    "metadata": {},
    "source": [
     "### Callbacks"
@@ -679,6 +736,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 113,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -688,6 +746,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 116,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -702,6 +761,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 118,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -725,6 +785,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 120,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -735,6 +796,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 122,
    "metadata": {},
    "source": [
     "### Scheduling the Learning Rate"
@@ -743,6 +805,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 124,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -765,6 +828,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 126,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -776,6 +840,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 128,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -786,6 +851,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 130,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -813,6 +879,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 132,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -823,6 +890,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 134,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -832,6 +900,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 136,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -840,6 +909,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 137,
    "metadata": {},
    "source": [
     "## Conclusion"
@@ -847,6 +917,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 139,
    "metadata": {},
    "source": [
     "## Questionnaire"
@@ -854,6 +925,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 140,
    "metadata": {},
    "source": [
     "> tip: Experiments: For the questions here that ask you to explain what some function or class is, you should also complete your own code experiments."
@@ -861,6 +933,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 141,
    "metadata": {},
    "source": [
     "1. What is `glob`?\n",
@@ -901,6 +974,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 142,
    "metadata": {},
    "source": [
     "### Further Research"
@@ -908,6 +982,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 143,
    "metadata": {},
    "source": [
     "1. Write `resnet18` from scratch (refer to <<chapter_resnet>> as needed), and train it with the `Learner` in this chapter.\n",
@@ -924,6 +999,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 144,
    "metadata": {},
    "outputs": [],
    "source": []
@@ -934,11 +1010,12 @@
    "split_at_heading": true
   },
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "python3",
    "language": "python",
    "name": "python3"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 2,
+ "path_": "19_learner.ipynb"
 }

--- a/clean/20_conclusion.ipynb
+++ b/clean/20_conclusion.ipynb
@@ -3,6 +3,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 0,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -14,6 +15,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 2,
    "metadata": {},
    "source": [
     "# Concluding Thoughts"
@@ -22,6 +24,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 6,
    "metadata": {},
    "outputs": [],
    "source": []
@@ -32,11 +35,12 @@
    "split_at_heading": true
   },
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "python3",
    "language": "python",
    "name": "python3"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 4
+ "nbformat_minor": 4,
+ "path_": "20_conclusion.ipynb"
 }

--- a/clean/20_conclusion.ipynb
+++ b/clean/20_conclusion.ipynb
@@ -3,7 +3,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 0,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -15,7 +14,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 2,
    "metadata": {},
    "source": [
     "# Concluding Thoughts"
@@ -24,7 +22,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 6,
    "metadata": {},
    "outputs": [],
    "source": []
@@ -41,6 +38,5 @@
   }
  },
  "nbformat": 4,
- "nbformat_minor": 4,
- "path_": "20_conclusion.ipynb"
+ "nbformat_minor": 4
 }

--- a/clean/app_blog.ipynb
+++ b/clean/app_blog.ipynb
@@ -2,6 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
+   "idx_": 1,
    "metadata": {},
    "source": [
     "# Creating a Blog"
@@ -9,6 +10,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 3,
    "metadata": {},
    "source": [
     "## Blogging with GitHub Pages"
@@ -16,6 +18,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 5,
    "metadata": {},
    "source": [
     "### Creating the Repository"
@@ -23,6 +26,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 7,
    "metadata": {},
    "source": [
     "### Setting Up Your Home Page"
@@ -30,6 +34,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 11,
    "metadata": {},
    "source": [
     "### Creating Posts"
@@ -37,6 +42,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 17,
    "metadata": {},
    "source": [
     "### Synchronizing GitHub and Your Computer"
@@ -44,6 +50,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 21,
    "metadata": {},
    "source": [
     "## Jupyter for Blogging"
@@ -52,6 +59,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 23,
    "metadata": {},
    "outputs": [],
    "source": []
@@ -62,11 +70,12 @@
    "split_at_heading": true
   },
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "python3",
    "language": "python",
    "name": "python3"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 2,
+ "path_": "app_blog.ipynb"
 }

--- a/clean/app_blog.ipynb
+++ b/clean/app_blog.ipynb
@@ -2,7 +2,6 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "idx_": 1,
    "metadata": {},
    "source": [
     "# Creating a Blog"
@@ -10,7 +9,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 3,
    "metadata": {},
    "source": [
     "## Blogging with GitHub Pages"
@@ -18,7 +16,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 5,
    "metadata": {},
    "source": [
     "### Creating the Repository"
@@ -26,7 +23,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 7,
    "metadata": {},
    "source": [
     "### Setting Up Your Home Page"
@@ -34,7 +30,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 11,
    "metadata": {},
    "source": [
     "### Creating Posts"
@@ -42,7 +37,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 17,
    "metadata": {},
    "source": [
     "### Synchronizing GitHub and Your Computer"
@@ -50,7 +44,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 21,
    "metadata": {},
    "source": [
     "## Jupyter for Blogging"
@@ -59,7 +52,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 23,
    "metadata": {},
    "outputs": [],
    "source": []
@@ -76,6 +68,5 @@
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2,
- "path_": "app_blog.ipynb"
+ "nbformat_minor": 2
 }

--- a/clean/app_jupyter.ipynb
+++ b/clean/app_jupyter.ipynb
@@ -3,6 +3,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 0,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -15,6 +16,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 1,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -23,6 +25,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 3,
    "metadata": {},
    "source": [
     "# Appendix: Jupyter Notebook 101"
@@ -30,6 +33,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 5,
    "metadata": {},
    "source": [
     "## Introduction"
@@ -38,6 +42,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 7,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -46,6 +51,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 9,
    "metadata": {},
    "source": [
     "## Writing"
@@ -54,6 +60,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 13,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -62,6 +69,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 14,
    "metadata": {},
    "source": [
     "## Modes"
@@ -69,6 +77,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 16,
    "metadata": {},
    "source": [
     "## Other Important Considerations"
@@ -76,6 +85,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 19,
    "metadata": {},
    "source": [
     "## Markdown Formatting\n"
@@ -83,6 +93,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 20,
    "metadata": {},
    "source": [
     "### Italics, Bold, Strikethrough, Inline, Blockquotes and Links"
@@ -90,6 +101,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 22,
    "metadata": {},
    "source": [
     "### Headings"
@@ -97,6 +109,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 24,
    "metadata": {},
    "source": [
     "### Lists"
@@ -104,6 +117,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 26,
    "metadata": {},
    "source": [
     "## Code Capabilities"
@@ -112,6 +126,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 28,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -123,6 +138,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 29,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -132,6 +148,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 30,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -145,6 +162,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 31,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -155,6 +173,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 33,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -163,6 +182,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 34,
    "metadata": {},
    "source": [
     "## Running the App Locally"
@@ -170,6 +190,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 36,
    "metadata": {},
    "source": [
     "## Creating a Notebook"
@@ -177,6 +198,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 38,
    "metadata": {},
    "source": [
     "## Shortcuts and Tricks"
@@ -184,6 +206,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 40,
    "metadata": {},
    "source": [
     "### Command Mode Shortcuts"
@@ -191,6 +214,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 42,
    "metadata": {},
    "source": [
     "### Cell Tricks"
@@ -198,6 +222,7 @@
   },
   {
    "cell_type": "markdown",
+   "idx_": 44,
    "metadata": {},
    "source": [
     "### Line Magics"
@@ -206,6 +231,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "idx_": 46,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -215,11 +241,12 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "python3",
    "language": "python",
    "name": "python3"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 2,
+ "path_": "app_jupyter.ipynb"
 }

--- a/clean/app_jupyter.ipynb
+++ b/clean/app_jupyter.ipynb
@@ -3,7 +3,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 0,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -16,7 +15,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 1,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -25,7 +23,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 3,
    "metadata": {},
    "source": [
     "# Appendix: Jupyter Notebook 101"
@@ -33,7 +30,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 5,
    "metadata": {},
    "source": [
     "## Introduction"
@@ -42,7 +38,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 7,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -51,7 +46,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 9,
    "metadata": {},
    "source": [
     "## Writing"
@@ -60,7 +54,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 13,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -69,7 +62,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 14,
    "metadata": {},
    "source": [
     "## Modes"
@@ -77,7 +69,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 16,
    "metadata": {},
    "source": [
     "## Other Important Considerations"
@@ -85,7 +76,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 19,
    "metadata": {},
    "source": [
     "## Markdown Formatting\n"
@@ -93,7 +83,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 20,
    "metadata": {},
    "source": [
     "### Italics, Bold, Strikethrough, Inline, Blockquotes and Links"
@@ -101,7 +90,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 22,
    "metadata": {},
    "source": [
     "### Headings"
@@ -109,7 +97,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 24,
    "metadata": {},
    "source": [
     "### Lists"
@@ -117,7 +104,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 26,
    "metadata": {},
    "source": [
     "## Code Capabilities"
@@ -126,7 +112,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 28,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -138,7 +123,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 29,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -148,7 +132,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 30,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -162,7 +145,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 31,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -173,7 +155,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 33,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -182,7 +163,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 34,
    "metadata": {},
    "source": [
     "## Running the App Locally"
@@ -190,7 +170,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 36,
    "metadata": {},
    "source": [
     "## Creating a Notebook"
@@ -198,7 +177,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 38,
    "metadata": {},
    "source": [
     "## Shortcuts and Tricks"
@@ -206,7 +184,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 40,
    "metadata": {},
    "source": [
     "### Command Mode Shortcuts"
@@ -214,7 +191,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 42,
    "metadata": {},
    "source": [
     "### Cell Tricks"
@@ -222,7 +198,6 @@
   },
   {
    "cell_type": "markdown",
-   "idx_": 44,
    "metadata": {},
    "source": [
     "### Line Magics"
@@ -231,7 +206,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "idx_": 46,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -247,6 +221,5 @@
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2,
- "path_": "app_jupyter.ipynb"
+ "nbformat_minor": 2
 }

--- a/environment.yml
+++ b/environment.yml
@@ -7,6 +7,8 @@ dependencies:
   - python>=3.6
   - pytorch>=1.6
   - torchvision
+  - execnb
+  - nbformat
   - pip
   - pip:
     - -r requirements.txt

--- a/tools/clean.py
+++ b/tools/clean.py
@@ -4,6 +4,7 @@ import nbformat
 from nbdev.export import *
 from nbdev.clean import *
 from fastcore.all import *
+from execnb.nbio import *
 
 _re_header = re.compile(r'^#+\s+\S+')
 _re_clean  = re.compile(r'^\s*#\s*clean\s*')

--- a/tools/clean.py
+++ b/tools/clean.py
@@ -31,6 +31,11 @@ def proc_nb(fname, dest):
     nb['cells'] = [clean_tags(c) for j,c in enumerate(nb['cells']) if
                    c['cell_type']=='code' or is_header_cell(c) or is_clean_cell(c) or j >= i]
     clean_nb(nb, clear_all=True)
+    if 'path_' in nb:
+        del nb['path_']
+    for c in nb['cells']:
+        if 'idx_' in c:
+            del c['idx_']
     with open(dest/fname.name, 'w') as f: nbformat.write(nb, f, version=4)
 
 def proc_all(path='.', dest_path='clean'):


### PR DESCRIPTION
Regenerating before making change to one of the notebooks. 

Surprisingly (or because of my lack of knowledge of how to use `nbdev`/`execnb` libs) current `read_nb()` function adds these unexpected keys to notebook JSON: 
1) `idx_` to all the cells
2) `path_` to the root

These result in errors of the following type when notebook is opened:
```
Notebook validation failed: Additional properties are not allowed ('idx_' was unexpected):
```

To address this issue, the `proc_nb()` function has been modified to forcefully delete these keys. Future improvements could involve implementing a cleaner solution, such as refining the `clean_nb()` function in the `nbdev` library.