### PR TITLE
add background color to neuron diagram

### DIFF
--- a/01_intro.ipynb
+++ b/01_intro.ipynb
@@ -126,7 +126,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "<img alt=\"Natural and artificial neurons\" width=\"500\" caption=\"Natural and artificial neurons\" src=\"images/chapter7_neuron.png\" id=\"neuron\"/>"
+    "<img alt=\"Natural and artificial neurons\" width=\"500\" caption=\"Natural and artificial neurons\" src=\"images/chapter7_neuron.png\" id=\"neuron\" style=\"background-color: white\"/>"
    ]
   },
   {


### PR DESCRIPTION
The diagram in [Neural Networks: A Brief History](https://console.paperspace.com/jgyaniv/notebook/r3ekcq8m2fc37nj?file=%2F01_intro.ipynb#Neural-Networks:-A-Brief-History) is transparent so the black text is not readable when the notebook is in dark mode. The solution is to just add a background color to the diagram using css.

Before:
<img width="941" alt="Screen Shot 2023-04-15 at 11 38 30 PM" src="https://user-images.githubusercontent.com/36972296/232265120-ab3347bc-3243-4bb4-b9ad-a1eace3d13de.png">

After:
<img width="932" alt="Screen Shot 2023-04-15 at 11 38 41 PM" src="https://user-images.githubusercontent.com/36972296/232265129-afd48555-9c97-403e-894b-8982e57c6dd4.png">

