### PR TITLE
Fix spelling error in 05_pet_breeds.ipynb

### DIFF
--- a/05_pet_breeds.ipynb
+++ b/05_pet_breeds.ipynb
@@ -208,7 +208,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "This regular expression plucks out all the characters leading up to the last underscore character, as long as the subsequence characters are numerical digits and then the JPEG file extension.\n",
+    "This regular expression plucks out all the characters leading up to the last underscore character, as long as the subsequent characters are numerical digits and then the JPEG file extension.\n",
     "\n",
     "Now that we confirmed the regular expression works for the example, let's use it to label the whole dataset. fastai comes with many classes to help with labeling. For labeling with regular expressions, we can use the `RegexLabeller` class. In this example we use the data block API we saw in <<chapter_production>> (in fact, we nearly always use the data block API—it's so much more flexible than the simple factory methods we saw in <<chapter_intro>>):"
    ]


### PR DESCRIPTION
spelling error. referencing "subsequence characters" when I believe it is supposed to read "subsequent characters"