### PR TITLE
Update 06_multicat.ipynb

### DIFF
--- a/06_multicat.ipynb
+++ b/06_multicat.ipynb
@@ -922,7 +922,7 @@
    ],
    "source": [
     "x,y = to_cpu(dls.train.one_batch())\n",
-    "activs = learn.model(x)\n",
+    "activs = TensorBase(learn.model(x))\n",
     "activs.shape"
    ]
   },


### PR DESCRIPTION
This activs previously gave TensorImage but we can not run BSELossWithLogits on TensorImage implementation. In this repo, the output of your cell is in TensorBase, which is correct, but in actual it was throwing output as TensorImage