### PR TITLE
Update 02_production.ipynb

### DIFF
--- a/02_production.ipynb
+++ b/02_production.ipynb
@@ -367,7 +367,7 @@
    ],
    "source": [
     "results = search_images_bing(key, 'grizzly bear')\n",
-    "ims = results.attrgot('contentUrl')\n",
+    "ims = results.attrgot('thumbnailUrl')\n",
     "len(ims)"
    ]
   },


### PR DESCRIPTION
Microsoft updated '_Bing Image Search API_' which made the previouse 'key: ```contentUrl```' incompatible.
Correctly updated the 'key: ```thumbnailUrl```' for accessing the image's URL.

This completely solves the issue #587 together with the pull request **fastai/fastbook** #620.