### PR TITLE
Fix broken link in ch1 to fast.ai datasets

### DIFF
--- a/01_intro.ipynb
+++ b/01_intro.ipynb
@@ -1490,7 +1490,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The second line downloads a standard dataset from the [fast.ai datasets collection](https://course.fast.ai/datasets) (if not previously downloaded) to your server, extracts it (if not previously extracted), and returns a `Path` object with the extracted location:\n",
+    "The second line downloads a standard dataset from the [fast.ai datasets collection](https://docs.fast.ai/data.external.html#datasets) (if not previously downloaded) to your server, extracts it (if not previously extracted), and returns a `Path` object with the extracted location:\n",
     "\n",
     "```python\n",
     "path = untar_data(URLs.PETS)/'images'\n",


### PR DESCRIPTION
The link in chapter 1 to the datasets provided by fast.ai was broken. This pull request fixes the broken link.

Previously: https://course.fast.ai/datasets

Now: https://docs.fast.ai/data.external.html#datasets