### PR TITLE
use dtreeviz 1.4.1

### DIFF
--- a/09_tabular.ipynb
+++ b/09_tabular.ipynb
@@ -7,7 +7,7 @@
    "outputs": [],
    "source": [
     "#hide\n",
-    "! [ -e /content ] && pip install -Uqq fastbook kaggle waterfallcharts treeinterpreter dtreeviz\n",
+    "! [ -e /content ] && pip install -Uqq fastbook kaggle waterfallcharts treeinterpreter dtreeviz==1.4.1\n",
     "import fastbook\n",
     "fastbook.setup_book()"
    ]

--- a/clean/09_tabular.ipynb
+++ b/clean/09_tabular.ipynb
@@ -7,7 +7,7 @@
    "outputs": [],
    "source": [
     "#hide\n",
-    "! [ -e /content ] && pip install -Uqq fastbook kaggle waterfallcharts treeinterpreter dtreeviz\n",
+    "! [ -e /content ] && pip install -Uqq fastbook kaggle waterfallcharts treeinterpreter dtreeviz==1.4.1\n",
     "import fastbook\n",
     "fastbook.setup_book()"
    ]


### PR DESCRIPTION
The dtreeviz call in this book only works with dtreeviz 1.x. I tried to update the method call to use version 2, but I don't know enough about the library to do that. At least this gets the book so it works again.