### PR TITLE
Typo in requirements.txt line # 7, "scikit_learn" should be "scikit-learn" 

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,6 @@ ipywidgets
 matplotlib
 nbdev>=0.2.12
 pandas
-scikit_learn
+scikit-learn
 azure-cognitiveservices-search-imagesearch
 sentencepiece


### PR DESCRIPTION
In line # 7, of requirements.txt file, 
scikit-learn is misspelled, 
there is an "_" instead of "-"

Solution : a dash instead of an underscore

"scikit_learn" ==>> "scikit-learn" 

